### PR TITLE
feat: Remove password fields from registration forms as per updated specifications

### DIFF
--- a/client/app/complete-registration/page.tsx
+++ b/client/app/complete-registration/page.tsx
@@ -13,8 +13,7 @@ function CompleteRegistrationContent() {
   const [name, setName] = useState("")
   const [email, setEmail] = useState("")
   const [phone, setPhone] = useState("")
-  const [password, setPassword] = useState("")
-  const [confirmPassword, setConfirmPassword] = useState("")
+  // Password fields removed: attendees do not set passwords as part of complete registration per spec
   const [ticketType, setTicketType] = useState("Student Pass")
   const [department, setDepartment] = useState("")
   const [loading, setLoading] = useState(false)
@@ -49,17 +48,11 @@ function CompleteRegistrationContent() {
     e.preventDefault()
     setError(null)
 
-    if (password !== confirmPassword) {
-      setError("Passwords do not match")
-      return
-    }
-
     setLoading(true)
     try {
       await authApi.completeRegistration({
         inviteToken: token,
         name,
-        password,
         phoneNumber: phone,
         ticketType,
         department,
@@ -179,30 +172,7 @@ function CompleteRegistrationContent() {
             </select>
           </div>
 
-          <div>
-            <label className="block text-sm font-medium text-zinc-700 mb-1">Password *</label>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="w-full rounded-lg border border-zinc-300 px-4 py-2.5 text-sm focus:border-purple-500 focus:ring-2 focus:ring-purple-200 transition"
-              placeholder="••••••••"
-              required
-              minLength={6}
-            />
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-zinc-700 mb-1">Confirm Password *</label>
-            <input
-              type="password"
-              value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              className="w-full rounded-lg border border-zinc-300 px-4 py-2.5 text-sm focus:border-purple-500 focus:ring-2 focus:ring-purple-200 transition"
-              placeholder="••••••••"
-              required
-            />
-          </div>
+          {/* Password and confirm password removed from UI per spec */}
 
           <Button
             type="submit"

--- a/client/components/form/FormPage.tsx
+++ b/client/components/form/FormPage.tsx
@@ -14,7 +14,7 @@ export default function FormPage() {
   const [name, setName] = useState("")
   const [email, setEmail] = useState("")
   const [phone, setPhone] = useState("")
-  const [password, setPassword] = useState("")
+  // password removed per spec (attendees don't set passwords during registration)
   const [ticket, setTicket] = useState("Student Pass")
   const [designation, setDesignation] = useState("")
   const [department, setDepartment] = useState("")
@@ -94,7 +94,6 @@ export default function FormPage() {
       await authApi.register({
         name,
         email,
-        password,
         phoneNumber: phone,
         ticketType: ticket,
         designation,
@@ -106,7 +105,7 @@ export default function FormPage() {
       setName("")
       setEmail("")
       setPhone("")
-      setPassword("")
+  // password cleared in earlier versions; no longer used
       setTicket("Student Pass")
       setDesignation("")
       setDepartment("")
@@ -145,7 +144,7 @@ export default function FormPage() {
               <TextField label="Full Name" name="name" value={name} onChange={setName} required placeholder="John Doe" />
               <TextField label="Email" name="email" value={email} onChange={setEmail} required placeholder="you@example.com" />
               <TextField label="Phone Number" name="phone" value={phone} onChange={setPhone} required placeholder="080********" />
-              <TextField label="Password" name="password" value={password} onChange={setPassword} required placeholder="••••••••" type="password" />
+              {/* Password removed - attendees don't set a password during initial registration */}
               <TextField label="Designation" name="designation" value={designation} onChange={setDesignation} placeholder="e.g. PhD Student, Lecturer" />
               <TextField label="Department" name="department" value={department} onChange={setDepartment} placeholder="e.g. Computer Science" />
             </div>

--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -78,15 +78,15 @@ class AuthController {
   });
 
   register = asyncHandler(async (req: Request, res: Response): Promise<void> => {
-    const { name, email, password, phoneNumber, ticketType, designation, department } =
+    const { name, email, phoneNumber, ticketType, designation, department } =
       req.body;
 
     // Handle file upload - multer stores the file info in req.file
     const paymentProof = req.file ? req.file.filename : '';
 
-    if (!name || !email || !password || !phoneNumber || !ticketType) {
+    if (!name || !email || !phoneNumber || !ticketType) {
       throw new BadRequestError(
-        'Name, email, password, phone number, and ticket type are required.'
+        'Name, email, phone number, and ticket type are required.'
       );
     }
 
@@ -96,11 +96,10 @@ class AuthController {
       throw new BadRequestError('Email already registered.');
     }
 
-    // Create new user
+    // Create new user (no password for attendees)
     const user = await User.create({
       name,
       email,
-      password,
       phoneNumber,
       ticketType,
       designation,
@@ -272,10 +271,10 @@ class AuthController {
   );
 
   completeRegistration = asyncHandler(async (req: Request, res: Response): Promise<void> => {
-    const { inviteToken, name, password, phoneNumber, ticketType, designation, department } = req.body;
+    const { inviteToken, name, phoneNumber, ticketType, designation, department } = req.body;
 
-    if (!inviteToken || !name || !password || !phoneNumber || !ticketType) {
-      throw new BadRequestError('Invite token, name, password, phone number, and ticket type are required.');
+    if (!inviteToken || !name || !phoneNumber || !ticketType) {
+      throw new BadRequestError('Invite token, name, phone number, and ticket type are required.');
     }
 
     const user = await User.findOne({ inviteToken, inviteTokenExpires: { $gt: new Date() } });
@@ -287,7 +286,6 @@ class AuthController {
     const { token, dataUrl } = await generateQRCode({ email: user.email });
 
     user.name = name;
-    user.password = password;
     user.phoneNumber = phoneNumber;
     user.ticketType = ticketType;
     user.designation = designation;


### PR DESCRIPTION
This pull request removes password fields and related logic from both the attendee registration and complete registration flows, in accordance with updated specifications that attendees do not set passwords during these processes. The changes span both the frontend and backend, ensuring that password data is no longer collected, validated, or stored.

**Frontend changes:**

* **Complete Registration UI and Logic:** Removed password and confirm password fields, their state, and validation from the `CompleteRegistrationContent` component in `client/app/complete-registration/page.tsx`. The API call now omits password data. [[1]](diffhunk://#diff-abc701dff338294c0f5355732312b0b4225639e71946b16279c421d1b0c54479L16-R16) [[2]](diffhunk://#diff-abc701dff338294c0f5355732312b0b4225639e71946b16279c421d1b0c54479L52-L62) [[3]](diffhunk://#diff-abc701dff338294c0f5355732312b0b4225639e71946b16279c421d1b0c54479L182-R175)
* **Initial Registration UI and Logic:** Removed password field, state, and API payload from the registration form in `client/components/form/FormPage.tsx`. [[1]](diffhunk://#diff-81ef2203c350bebb3e8db84aa2849334e94af72f3b330cba0f066a3e0c747a5bL17-R17) [[2]](diffhunk://#diff-81ef2203c350bebb3e8db84aa2849334e94af72f3b330cba0f066a3e0c747a5bL97) [[3]](diffhunk://#diff-81ef2203c350bebb3e8db84aa2849334e94af72f3b330cba0f066a3e0c747a5bL109-R108) [[4]](diffhunk://#diff-81ef2203c350bebb3e8db84aa2849334e94af72f3b330cba0f066a3e0c747a5bL148-R147)

**Backend changes:**

* **Registration Endpoint:** Removed password from required fields and user creation logic in the `register` method of `AuthController` (`server/src/controllers/auth.controller.ts`). [[1]](diffhunk://#diff-673a50050f0420927aa855245898252a8c6ce0e96cc23ba57d600f426586520cL81-R89) [[2]](diffhunk://#diff-673a50050f0420927aa855245898252a8c6ce0e96cc23ba57d600f426586520cL99-L103)
* **Complete Registration Endpoint:** Removed password from required fields, payload, and user update logic in the `completeRegistration` method of `AuthController`. [[1]](diffhunk://#diff-673a50050f0420927aa855245898252a8c6ce0e96cc23ba57d600f426586520cL275-R277) [[2]](diffhunk://#diff-673a50050f0420927aa855245898252a8c6ce0e96cc23ba57d600f426586520cL290)