### PR TITLE
fixes: Multiple fixes across multiple aspects of the codebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+server/src/uploads
 idea

--- a/client/app/admin/dashboard/page.tsx
+++ b/client/app/admin/dashboard/page.tsx
@@ -17,7 +17,7 @@ type Attendee = {
   designation: string
   paymentStatus: "pending" | "approved" | "declined"
   paymentProof?: string
-  checkedIn: boolean
+  checkInStatus: "checked-in" | "not-checked-in"
   createdAt: string
 }
 
@@ -530,7 +530,7 @@ export default function AdminDashboardPage() {
                               {a.paymentStatus}
                             </span>
                           </td>
-                          <td className="p-3 text-center">{a.checkedIn ? "✅" : "❌"}</td>
+                          <td className="p-3 text-center">{a.checkInStatus === "checked-in" ? "✅" : "❌"}</td>
                         </tr>
                       ))}
                     </tbody>

--- a/client/app/admin/dashboard/page.tsx
+++ b/client/app/admin/dashboard/page.tsx
@@ -5,7 +5,6 @@ import { useAuth } from "@/context/AuthContext"
 import { Button } from "@/components/ui/button"
 import Logo from "@/components/Logo"
 import { adminApi } from "@/lib/api"
-import Image from "next/image"
 
 type Attendee = {
   _id: string
@@ -28,6 +27,13 @@ type Agent = {
   createdAt: string
 }
 
+type DashboardDataType = {
+  totalAttendeesCount: number
+  checkedInAttendeesCount: number
+  totalAgentsCount: number
+  pendingApprovalsCount: number
+}
+
 type TabType = "pending" | "attendees" | "agents" | "manual" | "invite"
 
 export default function AdminDashboardPage() {
@@ -42,6 +48,14 @@ export default function AdminDashboardPage() {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [editedTicketType, setEditedTicketType] = useState<string>("")
   const [imageSrc, setImageSrc] = useState<string | null>(null)
+
+  // Dashbord tab counts
+  const [dashboardData, setDashboardData] = useState<DashboardDataType>({
+    totalAttendeesCount: 0,
+    checkedInAttendeesCount: 0,
+    totalAgentsCount: 0,
+    pendingApprovalsCount: 0,
+  })
 
   useEffect(() => {
     if (selectedAttendee?.paymentProof) {
@@ -128,14 +142,27 @@ export default function AdminDashboardPage() {
     }
   }, [])
 
+  const fetchDashboardData = useCallback(async () => {
+    setLoading(true)
+    try {
+      const res = await adminApi.getDashboardData()
+      setDashboardData(res.data || res || {})
+    } catch {
+      setMessage({ type: "error", text: "Failed to load dashboard data" })
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
   // Fetch data based on active tab
   useEffect(() => {
+    fetchDashboardData()
     if (activeTab === "pending" || activeTab === "attendees") {
       fetchAttendees()
     } else if (activeTab === "agents") {
       fetchAgents()
     }
-  }, [activeTab, fetchAttendees, fetchAgents])
+  }, [activeTab, fetchAttendees, fetchAgents, fetchDashboardData])
 
   async function approveAttendee(id: string, ticketType: string) {
     try {
@@ -234,9 +261,9 @@ export default function AdminDashboardPage() {
   const allAttendees = attendees
 
   const tabs = [
-    { id: "pending" as TabType, label: "Pending Approvals", count: pendingAttendees.length },
-    { id: "attendees" as TabType, label: "All Attendees", count: allAttendees.length },
-    { id: "agents" as TabType, label: "Agents", count: agents.length },
+    { id: "pending" as TabType, label: "Pending Approvals", count: dashboardData.pendingApprovalsCount },
+    { id: "attendees" as TabType, label: "All Attendees", count: dashboardData.totalAttendeesCount },
+    { id: "agents" as TabType, label: "Agents", count: dashboardData.totalAgentsCount },
     { id: "manual" as TabType, label: "Manual Register" },
     { id: "invite" as TabType, label: "Invite User" },
   ]

--- a/client/app/admin/dashboard/page.tsx
+++ b/client/app/admin/dashboard/page.tsx
@@ -14,6 +14,7 @@ type Attendee = {
   phoneNumber?: string
   ticketType: string
   department?: string
+  designation: string
   paymentStatus: "pending" | "approved" | "declined"
   paymentProof?: string
   checkedIn: boolean
@@ -77,6 +78,7 @@ export default function AdminDashboardPage() {
     phoneNumber: "",
     ticketType: "Student Pass",
     department: "",
+    designation: "",
   })
 
   // Invite form
@@ -163,7 +165,7 @@ export default function AdminDashboardPage() {
     try {
       await adminApi.manualRegister(manualForm)
       setMessage({ type: "success", text: "Attendee registered! QR code sent via email." })
-      setManualForm({ name: "", email: "", phoneNumber: "", ticketType: "Student Pass", department: "" })
+      setManualForm({ name: "", email: "", phoneNumber: "", ticketType: "Student Pass", department: "", designation: "" })
       setActiveTab("attendees")
       fetchAttendees()
     } catch (err) {
@@ -347,6 +349,7 @@ export default function AdminDashboardPage() {
                   <p><strong>Name:</strong> {selectedAttendee.name}</p>
                   <p><strong>Email:</strong> {selectedAttendee.email}</p>
                   <p><strong>Phone:</strong> {selectedAttendee.phoneNumber}</p>
+                  <p><strong>Designation:</strong> {selectedAttendee.designation}</p>
                   <p><strong>Department:</strong> {selectedAttendee.department || "N/A"}</p>
                   <div>
                     <label className="block text-sm font-medium text-zinc-700 mb-1">Ticket Type</label>
@@ -509,6 +512,14 @@ export default function AdminDashboardPage() {
                   value={manualForm.phoneNumber}
                   onChange={(e) => setManualForm({ ...manualForm, phoneNumber: e.target.value })}
                   placeholder="Phone number"
+                  className="w-full rounded-lg border border-zinc-300 px-4 py-2.5 text-sm"
+                  required
+                />
+                <input
+                  type="text"
+                  value={manualForm.designation}
+                  onChange={(e) => setManualForm({ ...manualForm, designation: e.target.value })}
+                  placeholder="Designation (e.g. PhD Student, Lecturer)"
                   className="w-full rounded-lg border border-zinc-300 px-4 py-2.5 text-sm"
                   required
                 />

--- a/client/app/admin/dashboard/page.tsx
+++ b/client/app/admin/dashboard/page.tsx
@@ -49,6 +49,9 @@ export default function AdminDashboardPage() {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [editedTicketType, setEditedTicketType] = useState<string>("")
   const [imageSrc, setImageSrc] = useState<string | null>(null)
+  const [imageLoading, setImageLoading] = useState(false)
+  const [imageError, setImageError] = useState<string | null>(null)
+  const [imageMimeType, setImageMimeType] = useState<string | null>(null)
 
   const [confirmState, setConfirmState] = useState<
     | { open: false }
@@ -72,17 +75,35 @@ export default function AdminDashboardPage() {
     if (selectedAttendee?.paymentProof) {
       let objectUrl: string
       const fetchImage = async () => {
+        setImageLoading(true)
+        setImageError(null)
+        setImageMimeType(null)
+        setImageSrc(null)
         try {
-          const response = await fetch(selectedAttendee.paymentProof!)
+          // Use a credentialed request by default; many receipts live behind auth cookies.
+          const response = await fetch(selectedAttendee.paymentProof!, {
+            credentials: "include",
+            headers: {
+              Accept: "image/*,application/pdf;q=0.9,*/*;q=0.8",
+            },
+          })
           if (!response.ok) {
-            throw new Error("Network response was not ok")
+            throw new Error(`Failed to load receipt (HTTP ${response.status})`)
           }
           const blob = await response.blob()
+
+          // Some receipts might be PDFs or other formats.
+          const mime = blob.type || null
+          setImageMimeType(mime)
+
           objectUrl = URL.createObjectURL(blob)
           setImageSrc(objectUrl)
         } catch (error) {
-          console.error("Failed to fetch image:", error)
-          setImageSrc(null) // Or a placeholder image
+          console.error("Failed to fetch receipt:", error)
+          setImageSrc(null)
+          setImageError(error instanceof Error ? error.message : "Failed to load receipt")
+        } finally {
+          setImageLoading(false)
         }
       }
 
@@ -94,6 +115,12 @@ export default function AdminDashboardPage() {
         }
       }
     }
+
+    // If no payment proof, clear any previous state.
+    setImageSrc(null)
+    setImageError(null)
+    setImageMimeType(null)
+    setImageLoading(false)
   }, [selectedAttendee])
 
   // Manual registration form
@@ -464,14 +491,60 @@ export default function AdminDashboardPage() {
                   {selectedAttendee.paymentProof && (
                     <div className="mt-4">
                       <p className="font-medium mb-2">Payment Receipt</p>
-                      {imageSrc ? (
-                        <img
-                          src={imageSrc}
-                          alt="Payment Receipt"
-                          className="w-full h-auto rounded-lg border"
-                        />
+                      {imageLoading ? (
+                        <p className="text-sm text-zinc-500">Loading receipt…</p>
+                      ) : imageError ? (
+                        <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                          <div className="font-medium mb-1">Couldn’t load receipt</div>
+                          <div className="text-red-700/90">{imageError}</div>
+                          <div className="mt-2">
+                            <a
+                              href={selectedAttendee.paymentProof}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="underline"
+                            >
+                              Open receipt in a new tab
+                            </a>
+                          </div>
+                        </div>
+                      ) : imageSrc ? (
+                        imageMimeType?.includes("pdf") ? (
+                          <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-3 text-sm">
+                            <p className="text-zinc-700">This receipt is a PDF.</p>
+                            <a
+                              href={imageSrc}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="mt-1 inline-block underline"
+                            >
+                              Open PDF
+                            </a>
+                          </div>
+                        ) : (
+                          // next/image doesn't support blob: URLs reliably + would require remotePatterns for API URLs.
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            src={imageSrc}
+                            alt="Payment Receipt"
+                            className="w-full h-auto rounded-lg border border-zinc-200 bg-white"
+                            loading="lazy"
+                          />
+                        )
                       ) : (
-                        <p>Loading image...</p>
+                        <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-3 text-sm text-zinc-600">
+                          No receipt preview available.
+                          <div className="mt-1">
+                            <a
+                              href={selectedAttendee.paymentProof}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="underline"
+                            >
+                              Open receipt
+                            </a>
+                          </div>
+                        </div>
                       )}
                     </div>
                   )}

--- a/client/app/admin/dashboard/page.tsx
+++ b/client/app/admin/dashboard/page.tsx
@@ -508,7 +508,7 @@ export default function AdminDashboardPage() {
                         <th className="text-left p-3">Email</th>
                         <th className="text-left p-3">Ticket</th>
                         <th className="text-left p-3">Status</th>
-                        <th className="text-left p-3">Checked In</th>
+                        <th className="text-center p-3">Checked In</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -530,7 +530,7 @@ export default function AdminDashboardPage() {
                               {a.paymentStatus}
                             </span>
                           </td>
-                          <td className="p-3">{a.checkedIn ? "✅ Yes" : "—"}</td>
+                          <td className="p-3 text-center">{a.checkedIn ? "✅" : "❌"}</td>
                         </tr>
                       ))}
                     </tbody>

--- a/client/app/admin/dashboard/page.tsx
+++ b/client/app/admin/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "@/context/AuthContext"
 import { Button } from "@/components/ui/button"
 import Logo from "@/components/Logo"
 import { adminApi } from "@/lib/api"
+import { ConfirmDialog } from "@/components/ui/confirm-dialog"
 
 type Attendee = {
   _id: string
@@ -48,6 +49,16 @@ export default function AdminDashboardPage() {
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [editedTicketType, setEditedTicketType] = useState<string>("")
   const [imageSrc, setImageSrc] = useState<string | null>(null)
+
+  const [confirmState, setConfirmState] = useState<
+    | { open: false }
+    | {
+        open: true
+        action: "approve" | "decline"
+        attendee: Attendee
+      }
+  >({ open: false })
+  const [confirmLoading, setConfirmLoading] = useState(false)
 
   // Dashbord tab counts
   const [dashboardData, setDashboardData] = useState<DashboardDataType>({
@@ -186,6 +197,28 @@ export default function AdminDashboardPage() {
     }
   }
 
+  async function handleConfirmAction() {
+    if (!confirmState.open) return
+    setConfirmLoading(true)
+    try {
+      if (confirmState.action === "approve") {
+        // Use edited ticket type if the details modal is open for the same attendee
+        const ticketType =
+          isModalOpen && selectedAttendee?._id === confirmState.attendee._id ? editedTicketType : confirmState.attendee.ticketType
+        await approveAttendee(confirmState.attendee._id, ticketType)
+      } else {
+        await declineAttendee(confirmState.attendee._id)
+        // If admin declines from within the details modal, close it to avoid stale state.
+        if (isModalOpen && selectedAttendee?._id === confirmState.attendee._id) {
+          setIsModalOpen(false)
+        }
+      }
+      setConfirmState({ open: false })
+    } finally {
+      setConfirmLoading(false)
+    }
+  }
+
   async function handleManualRegister(e: React.FormEvent) {
     e.preventDefault()
     setLoading(true)
@@ -270,6 +303,41 @@ export default function AdminDashboardPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-indigo-50 to-white">
+      <ConfirmDialog
+        open={confirmState.open}
+        title={
+          confirmState.open
+            ? confirmState.action === "approve"
+              ? "Approve payment?"
+              : "Decline payment?"
+            : ""
+        }
+        description={
+          confirmState.open ? (
+            <div className="space-y-2">
+              <div>
+                You’re about to <span className="font-medium">{confirmState.action}</span> payment for:
+              </div>
+              <div className="rounded-lg border border-zinc-200 bg-zinc-50 p-3 text-sm">
+                <div className="font-medium text-zinc-900">{confirmState.attendee.name}</div>
+                <div className="text-zinc-600">{confirmState.attendee.email}</div>
+                <div className="text-zinc-600">Ticket: {confirmState.attendee.ticketType}</div>
+              </div>
+              {confirmState.action === "decline" ? (
+                <div className="text-sm text-zinc-600">This will mark the payment as declined.</div>
+              ) : (
+                <div className="text-sm text-zinc-600">This will approve the payment and send the QR code via email.</div>
+              )}
+            </div>
+          ) : null
+        }
+        confirmText={confirmState.open ? (confirmState.action === "approve" ? "Approve" : "Decline") : "Confirm"}
+        cancelText="Cancel"
+        variant={confirmState.open && confirmState.action === "decline" ? "danger" : "default"}
+        loading={confirmLoading}
+        onCancel={() => (confirmLoading ? null : setConfirmState({ open: false }))}
+        onConfirm={handleConfirmAction}
+      />
       {/* Header */}
       <header className="bg-white/80 backdrop-blur border-b border-zinc-200 sticky top-0 z-10">
         <div className="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
@@ -285,7 +353,6 @@ export default function AdminDashboardPage() {
           </Button>
         </div>
       </header>
-
       <div className="max-w-7xl mx-auto px-4 py-6">
         {/* Message */}
         {message && (
@@ -355,7 +422,11 @@ export default function AdminDashboardPage() {
                         >
                           View Details
                         </Button>
-                        <Button onClick={() => declineAttendee(attendee._id)} variant="outline" className="text-red-600 border-red-300 hover:bg-red-50">
+                        <Button
+                          onClick={() => setConfirmState({ open: true, action: "decline", attendee })}
+                          variant="outline"
+                          className="text-red-600 border-red-300 hover:bg-red-50"
+                        >
                           Decline
                         </Button>
                       </div>
@@ -408,7 +479,10 @@ export default function AdminDashboardPage() {
                     <Button variant="outline" onClick={() => setIsModalOpen(false)}>
                       Close
                     </Button>
-                    <Button onClick={() => approveAttendee(selectedAttendee._id, editedTicketType)} className="bg-green-600 hover:bg-green-700">
+                    <Button
+                      onClick={() => setConfirmState({ open: true, action: "approve", attendee: selectedAttendee })}
+                      className="bg-green-600 hover:bg-green-700"
+                    >
                       Approve
                     </Button>
                   </div>

--- a/client/components/ui/confirm-dialog.tsx
+++ b/client/components/ui/confirm-dialog.tsx
@@ -1,0 +1,135 @@
+"use client"
+
+import * as React from "react"
+import { Button } from "@/components/ui/button"
+
+type ConfirmDialogVariant = "default" | "danger"
+
+type ConfirmDialogProps = {
+  open: boolean
+  title: string
+  description?: React.ReactNode
+  confirmText?: string
+  cancelText?: string
+  variant?: ConfirmDialogVariant
+  loading?: boolean
+  onConfirm: () => void | Promise<void>
+  onCancel: () => void
+}
+
+/**
+ * Lightweight confirm dialog (no external deps).
+ * - Accessible: role="dialog", aria-modal, Esc to close, click-backdrop to close.
+ * - Good default UX: focus management + disabled confirm when loading.
+ */
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmText = "Confirm",
+  cancelText = "Cancel",
+  variant = "default",
+  loading = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const panelRef = React.useRef<HTMLDivElement | null>(null)
+  const confirmBtnRef = React.useRef<HTMLButtonElement | null>(null)
+
+  React.useEffect(() => {
+    if (!open) return
+
+    // Focus confirm by default for quick approve flows.
+    const t = window.setTimeout(() => confirmBtnRef.current?.focus(), 0)
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel()
+      if (e.key === "Tab") {
+        // Minimal focus trap for 2 buttons
+        const focusables = panelRef.current?.querySelectorAll<HTMLElement>(
+          'button,[href],input,select,textarea,[tabindex]:not([tabindex="-1"])'
+        )
+        if (!focusables || focusables.length === 0) return
+        const first = focusables[0]
+        const last = focusables[focusables.length - 1]
+        const active = document.activeElement as HTMLElement | null
+
+        if (e.shiftKey) {
+          if (active === first) {
+            e.preventDefault()
+            last.focus()
+          }
+        } else {
+          if (active === last) {
+            e.preventDefault()
+            first.focus()
+          }
+        }
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown)
+    return () => {
+      window.clearTimeout(t)
+      document.removeEventListener("keydown", onKeyDown)
+    }
+  }, [open, onCancel])
+
+  if (!open) return null
+
+  const dangerStyles =
+    variant === "danger"
+      ? "bg-red-600 hover:bg-red-700 text-white"
+      : "bg-gradient-to-r from-purple-600 to-indigo-600 text-white hover:opacity-95"
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center px-4"
+      aria-hidden={!open}
+    >
+      {/* Backdrop */}
+      <button
+        type="button"
+        aria-label="Close dialog"
+        className="absolute inset-0 bg-black/50"
+        onClick={onCancel}
+      />
+
+      {/* Panel */}
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-dialog-title"
+        className="relative w-full max-w-md rounded-2xl bg-white shadow-2xl border border-zinc-200 p-5"
+      >
+        <h3 id="confirm-dialog-title" className="text-base font-semibold text-zinc-900">
+          {title}
+        </h3>
+
+        {description ? (
+          <div className="mt-2 text-sm text-zinc-600 leading-relaxed">{description}</div>
+        ) : null}
+
+        <div className="mt-5 flex items-center justify-end gap-2">
+          <Button variant="outline" onClick={onCancel} disabled={loading}>
+            {cancelText}
+          </Button>
+
+          <Button
+            ref={(el) => {
+              // Button from shadcn may not forward ref typed correctly; handle gracefully
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              confirmBtnRef.current = el as any
+            }}
+            onClick={onConfirm}
+            disabled={loading}
+            className={dangerStyles}
+          >
+            {loading ? "Please wait..." : confirmText}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -208,7 +208,7 @@ export const adminApi = {
   approveRegistration: async (id: string, data: { ticketType: string }) => (await api.post(`/admin/attendees/${id}/approve`, data)).data,
   declineRegistration: async (id: string) => (await api.post(`/admin/attendees/${id}/decline`)).data,
   getAllAttendees: async () => (await api.get('/admin/attendees')).data,
-  getDashboard: async () => (await api.get('/admin/dashboard')).data,
+  getDashboardData: async () => (await api.get('/admin/dashboard')).data,
 }
 
 // Scan API

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "ecouniben-backend",
+  "name": "dridcon-backend",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "ecouniben-backend",
+      "name": "dridcon-backend",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/server/src/controllers/admin.controller.ts
+++ b/server/src/controllers/admin.controller.ts
@@ -112,6 +112,7 @@ class AdminController {
         paymentStatus: PaymentStatus.CONFIRMED,
         role: UserRole.USER,
         checkInStatus: CheckInStatus.NOT_CHECKED_IN,
+        ticketsent: true,
       });
 
       const qrCodeUrl = `${process.env.API_URL}${filePath}`;
@@ -230,6 +231,10 @@ class AdminController {
         qrCodeUrl,
         attendee.ticketType
       );
+
+      // Update ticketsent to true
+      attendee.ticketsent = true;
+      await attendee.save();
 
       res.status(200).json({
         success: true,

--- a/server/src/controllers/admin.controller.ts
+++ b/server/src/controllers/admin.controller.ts
@@ -1,7 +1,7 @@
 import { Response } from 'express';
 import asyncHandler from '../utils/asyncHandler';
 import logger from '../utils/logger';
-import User, { PaymentStatus, UserRole } from '../model/user.model';
+import User, { PaymentStatus, UserRole, CheckInStatus } from '../model/user.model';
 import {
   BadRequestError,
   NotFoundError,
@@ -111,6 +111,7 @@ class AdminController {
         qrCode: token,
         paymentStatus: PaymentStatus.CONFIRMED,
         role: UserRole.USER,
+        checkInStatus: CheckInStatus.NOT_CHECKED_IN,
       });
 
       const qrCodeUrl = `${process.env.API_URL}${filePath}`;

--- a/server/src/controllers/admin.controller.ts
+++ b/server/src/controllers/admin.controller.ts
@@ -291,17 +291,24 @@ class AdminController {
         );
       }
 
-      const totalAttendees = await User.countDocuments({ role: UserRole.USER });
-      const checkedInAttendees = await User.countDocuments({
+      const totalAttendeesCount = await User.countDocuments({ role: UserRole.USER });
+      const checkedInAttendeesCount = await User.countDocuments({
         role: UserRole.USER,
         checkInStatus: 'checked-in',
+      });
+      const totalAgentsCount = await User.countDocuments({ role: UserRole.AGENT });
+      const pendingApprovalsCount = await User.countDocuments({
+        role: UserRole.USER,
+        paymentStatus: PaymentStatus.PENDING,
       });
 
       res.status(200).json({
         success: true,
         data: {
-          totalAttendees,
-          checkedInAttendees,
+          totalAttendeesCount,
+          checkedInAttendeesCount,
+          totalAgentsCount,
+          pendingApprovalsCount,
         },
       });
     }

--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express';
-import User, { UserRole, PaymentStatus } from '../model/user.model';
+import User, { UserRole, PaymentStatus, CheckInStatus } from '../model/user.model';
 import tokenService, { TokenPayload } from '../services/token.service'; // Import TokenPayload
 import { UnauthorizedError, BadRequestError } from '../utils/customErrors';
 import asyncHandler from '../utils/asyncHandler';
@@ -114,6 +114,7 @@ class AuthController {
       fileType: req.file ? req.file.mimetype : '',
       role: UserRole.USER,
       isActive: true,
+      checkInStatus: CheckInStatus.NOT_CHECKED_IN,
     });
 
     // Send registration confirmation email

--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -115,6 +115,7 @@ class AuthController {
       role: UserRole.USER,
       isActive: true,
       checkInStatus: CheckInStatus.NOT_CHECKED_IN,
+      ticketsent: false,
     });
 
     // Send registration confirmation email

--- a/server/src/model/user.model.ts
+++ b/server/src/model/user.model.ts
@@ -32,6 +32,7 @@ export interface IUser extends Document {
   password?: string;
   role: UserRole;
   isActive: boolean;
+  ticketsent?: boolean;
   refreshToken?: string;
   inviteToken?: string;
   inviteTokenExpires?: Date;

--- a/server/src/services/email.service.ts
+++ b/server/src/services/email.service.ts
@@ -30,7 +30,7 @@ class EmailService {
     this.transporter = nodemailer.createTransport({
       host: process.env.SMTP_HOST,
       port: parseInt(process.env.SMTP_PORT || '465'),
-      secure: true,
+      secure: process.env.SMTP_PORT === '465', // true for 465, false for other ports
       auth: {
         user: process.env.SMTP_USER,
         pass: process.env.SMTP_PASS,

--- a/server/src/services/token.service.ts
+++ b/server/src/services/token.service.ts
@@ -64,7 +64,7 @@ class TokenService {
       {
         ...payload,
         iat: now,
-        exp: now + 15 * 60, // 15 minutes
+        exp: now + (15 * 60), // 15 minutes
       },
       this.accessTokenSecret
     );
@@ -73,7 +73,7 @@ class TokenService {
       {
         ...payload,
         iat: now,
-        exp: now + 7 * 24 * 60 * 60, // 7 days
+        exp: now + (7 * 24 * 60 * 60), // 7 days
       },
       this.refreshTokenSecret
     );


### PR DESCRIPTION
1 [Complete]
Add a ticketsent: true field
So on the day of the event we'll add a send ticket again button, then also create a template to send a reminder to everyone with ticketsent: true a day to the event. 
Then we should add a way to send follow up copy email templates talking about the event.

3 [Fixed: it exist in the backend so when I just added it to the frontend everything worked as expected]
There's no designation field in the manual register field probably in the backend too.

4 [Completed]
also clicking on decline or approve in the pending approval tab should bring out another modal telling you to confirm first, to avoid the mistake of just clicking on it by mistake

5 [Complete, unused endpoint now used]
Figure out while on first load the agents number is 0, until you navigate to the agents tab before it loads the current correct number

6 [Completed]
After checking in someone,  in the admin dashboard, isn't there a checked in status,because I'm still seeing a dash there in the checked in field for someone who has been checked in?