### PR TITLE
feat: Add manual check-ins, agent scan history, and client/server CI workflows

### DIFF
--- a/.github/workflows/client-ci.yml
+++ b/.github/workflows/client-ci.yml
@@ -1,0 +1,39 @@
+name: Client CI
+
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  client:
+    name: Client lint & build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: client
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: client/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -1,0 +1,38 @@
+name: Server CI
+
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  server:
+    name: Server lint & build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: server/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/client/app/admin/dashboard/page.tsx
+++ b/client/app/admin/dashboard/page.tsx
@@ -22,12 +22,33 @@ type Attendee = {
   mainConferenceQrCode?: string
   preConferenceCheckInStatus?: "checked-in" | "not-checked-in"
   mainConferenceCheckInStatus?: "checked-in" | "not-checked-in"
+  preConferenceCheckInSource?: "qr" | "manual"
+  mainConferenceCheckInSource?: "qr" | "manual"
   createdAt: string,
   referralCode?: string,
   wantsPreConference?: boolean,
   preConferenceInviteSent?: boolean,
   preConferenceDeclinedDuringReg?: boolean,
   preConferenceInviteResponse?: 'pending' | 'yes' | 'no',
+}
+
+type ScanHistoryItem = {
+  _id: string
+  name: string
+  email: string
+  ticketType: string
+  scannedAt: string
+  scanStatus: "success" | "already_scanned" | "invalid"
+  scanSource?: "qr" | "manual"
+  sessionType?: "pre-conference" | "main-conference"
+  message?: string
+}
+
+type ScanHistoryStats = {
+  totalScans: number
+  successfulCheckIns: number
+  successfulManualCheckIns: number
+  successfulQrScans: number
 }
 
 type Agent = {
@@ -91,12 +112,18 @@ const [instantForm, setInstantForm] = useState<InstantFormState>({
     | { open: false }
     | {
         open: true
-        action: "approve" | "decline" | "sendPreConferenceInvite"
+        action: "approve" | "decline" | "sendPreConferenceInvite" | "manualCheckIn"
         attendee: Attendee
         sessionType?: 'pre-conference' | 'main-conference'
       }
   >({ open: false })
   const [confirmLoading, setConfirmLoading] = useState(false)
+
+  const [selectedAgentId, setSelectedAgentId] = useState<string>("")
+  const [agentScanHistory, setAgentScanHistory] = useState<ScanHistoryItem[]>([])
+  const [agentScanStats, setAgentScanStats] = useState<ScanHistoryStats | null>(null)
+  const [agentScanLoading, setAgentScanLoading] = useState(false)
+  const [agentScanError, setAgentScanError] = useState<string | null>(null)
 
   // Dashbord tab counts
   const [dashboardData, setDashboardData] = useState<DashboardDataType>({
@@ -105,6 +132,54 @@ const [instantForm, setInstantForm] = useState<InstantFormState>({
     totalAgentsCount: 0,
     pendingApprovalsCount: 0,
   })
+
+  const formatDateTime = (value?: string) => {
+    if (!value) return ""
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) return String(value)
+    return date.toLocaleString()
+  }
+
+  const renderSourceBadge = (source?: "qr" | "manual") => {
+    if (!source) return null
+    const isManual = source === "manual"
+    return (
+      <span
+        className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${
+          isManual ? "bg-indigo-100 text-indigo-800" : "bg-emerald-100 text-emerald-800"
+        }`}
+      >
+        {isManual ? "Manual" : "QR"}
+      </span>
+    )
+  }
+
+  const fetchAgentScanHistory = useCallback(
+    async (agentId: string) => {
+      if (!agentId) {
+        setAgentScanHistory([])
+        setAgentScanStats(null)
+        return
+      }
+
+      setAgentScanLoading(true)
+      setAgentScanError(null)
+      try {
+        const res = await adminApi.getAgentScanHistory(agentId)
+        const data = res?.data
+        setAgentScanHistory(Array.isArray(data?.history) ? data.history : [])
+        setAgentScanStats(data?.stats ?? null)
+      } catch (error) {
+        console.error("Failed to fetch agent scan history:", error)
+        setAgentScanError("Failed to load scan history")
+        setAgentScanHistory([])
+        setAgentScanStats(null)
+      } finally {
+        setAgentScanLoading(false)
+      }
+    },
+    []
+  )
 
   useEffect(() => {
     if (selectedAttendee?.paymentProof) {
@@ -314,6 +389,15 @@ const [instantForm, setInstantForm] = useState<InstantFormState>({
         await approveAttendee(confirmState.attendee._id, ticketType, confirmState.sessionType)
       } else if (confirmState.action === 'sendPreConferenceInvite') {
         await handleSendPreConferenceInvite(confirmState.attendee._id);
+      } else if (confirmState.action === 'manualCheckIn') {
+        if (confirmState.sessionType === 'pre-conference') {
+          await adminApi.manualCheckInPreConference(confirmState.attendee._id)
+          setMessage({ type: 'success', text: 'Pre-conference manual check-in successful.' })
+        } else {
+          await adminApi.manualCheckInMainConference(confirmState.attendee._id)
+          setMessage({ type: 'success', text: 'Main conference manual check-in successful.' })
+        }
+        fetchAttendees()
       }
       else {
         await declineAttendee(confirmState.attendee._id)
@@ -460,6 +544,10 @@ async function handleInstantCheckIn(e: React.FormEvent) {
           confirmState.open
             ? confirmState.action === "approve"
               ? "Approve payment?"
+              : confirmState.action === 'manualCheckIn'
+              ? (confirmState.sessionType === 'pre-conference'
+                  ? 'Confirm pre-conference manual check-in?'
+                  : 'Confirm main conference manual check-in?')
               : confirmState.action === 'sendPreConferenceInvite'
               ? 'Send pre-conference invite?'
               : "Decline payment?"
@@ -478,6 +566,8 @@ async function handleInstantCheckIn(e: React.FormEvent) {
               </div>
               {confirmState.action === "decline" ? (
                 <div className="text-sm text-zinc-600">This will mark the payment as declined.</div>
+              ) : confirmState.action === 'manualCheckIn' ? (
+                <div className="text-sm text-red-600">This action is not reversible. Please confirm you’re checking in the correct person.</div>
               ) : confirmState.action === 'sendPreConferenceInvite' ? (
                 <div className="text-sm text-zinc-600">This will send an email to the user with a link to respond to the pre-conference invite.</div>
               ) : (
@@ -490,13 +580,15 @@ async function handleInstantCheckIn(e: React.FormEvent) {
           confirmState.open 
             ? confirmState.action === "approve" 
               ? "Approve" 
+              : confirmState.action === 'manualCheckIn'
+              ? (confirmState.sessionType === 'pre-conference' ? 'Check in (Pre-Conf)' : 'Check in (Main Conf)')
               : confirmState.action === 'sendPreConferenceInvite'
               ? 'Send Invite'
               : "Decline" 
             : "Confirm"
         }
         cancelText="Cancel"
-        variant={confirmState.open && confirmState.action === "decline" ? "danger" : "default"}
+        variant={confirmState.open && (confirmState.action === "decline" || confirmState.action === 'manualCheckIn') ? "danger" : "default"}
         loading={confirmLoading}
         onCancel={() => (confirmLoading ? null : setConfirmState({ open: false }))}
         onConfirm={handleConfirmAction}
@@ -855,15 +947,54 @@ async function handleInstantCheckIn(e: React.FormEvent) {
       </td>
       <td className="p-3 text-center">
         {(a.ticketType === 'Lecturer Premium' || (a.ticketType === 'Researcher Premium' && a.preConferenceQrCode)) ? (
-          a.preConferenceCheckInStatus === "checked-in" ? "✅" : "❌"
+          a.preConferenceCheckInStatus === "checked-in" ? (
+            <div className="inline-flex flex-col items-center gap-1">
+              <span>✅</span>
+              {renderSourceBadge(a.preConferenceCheckInSource)}
+            </div>
+          ) : (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setConfirmState({ open: true, action: 'manualCheckIn', attendee: a, sessionType: 'pre-conference' })}
+            >
+              Check in
+            </Button>
+          )
         ) : (
           <span className="text-zinc-400">N/A</span>
         )}
       </td>
       <td className="p-3 text-center">
         {(a.ticketType === 'Lecturer Premium' || (a.ticketType === 'Researcher Premium' && a.preConferenceQrCode)) 
-          ? (a.mainConferenceCheckInStatus === "checked-in" ? "✅" : "❌")
-          : (a.checkInStatus === "checked-in" ? "✅" : "❌")
+          ? (a.mainConferenceCheckInStatus === "checked-in" ? (
+            <div className="inline-flex flex-col items-center gap-1">
+              <span>✅</span>
+              {renderSourceBadge(a.mainConferenceCheckInSource)}
+            </div>
+          ) : (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setConfirmState({ open: true, action: 'manualCheckIn', attendee: a, sessionType: 'main-conference' })}
+            >
+              Check in
+            </Button>
+          ))
+          : (a.checkInStatus === "checked-in" ? (
+            <div className="inline-flex flex-col items-center gap-1">
+              <span>✅</span>
+              {renderSourceBadge(a.mainConferenceCheckInSource)}
+            </div>
+          ) : (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setConfirmState({ open: true, action: 'manualCheckIn', attendee: a, sessionType: 'main-conference' })}
+            >
+              Check in
+            </Button>
+          ))
         }
       </td>
     </tr>
@@ -901,6 +1032,120 @@ async function handleInstantCheckIn(e: React.FormEvent) {
                     {loading ? "Adding..." : "Add Agent"}
                   </Button>
                 </form>
+              </div>
+
+              <div className="border rounded-xl p-4 bg-white">
+                <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                  <div>
+                    <h2 className="text-lg font-semibold">Agent Scan History</h2>
+                    <p className="text-sm text-zinc-500">View QR and manual check-ins (including failed scans).</p>
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    <select
+                      className="rounded-lg border border-zinc-300 px-3 py-2 text-sm"
+                      value={selectedAgentId}
+                      onChange={(e) => {
+                        const next = e.target.value
+                        setSelectedAgentId(next)
+                        fetchAgentScanHistory(next)
+                      }}
+                    >
+                      <option value="">Select an agent…</option>
+                      {agents.map((a) => (
+                        <option key={a._id} value={a._id}>
+                          {a.name} ({a.email})
+                        </option>
+                      ))}
+                    </select>
+
+                    <Button
+                      variant="outline"
+                      disabled={!selectedAgentId || agentScanLoading}
+                      onClick={() => fetchAgentScanHistory(selectedAgentId)}
+                    >
+                      {agentScanLoading ? "Loading…" : "Refresh"}
+                    </Button>
+                  </div>
+                </div>
+
+                {agentScanError ? (
+                  <div className="mt-3 bg-red-50 border border-red-200 text-red-700 rounded-lg p-3 text-sm">
+                    {agentScanError}
+                  </div>
+                ) : null}
+
+                {selectedAgentId && agentScanStats ? (
+                  <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+                    <div className="rounded-lg border p-3">
+                      <p className="text-xs text-zinc-500">Total scans</p>
+                      <p className="text-xl font-semibold">{agentScanStats.totalScans}</p>
+                    </div>
+                    <div className="rounded-lg border p-3">
+                      <p className="text-xs text-zinc-500">Successful check-ins</p>
+                      <p className="text-xl font-semibold">{agentScanStats.successfulCheckIns}</p>
+                    </div>
+                    <div className="rounded-lg border p-3">
+                      <p className="text-xs text-zinc-500">Manual successes</p>
+                      <p className="text-xl font-semibold">{agentScanStats.successfulManualCheckIns}</p>
+                    </div>
+                    <div className="rounded-lg border p-3">
+                      <p className="text-xs text-zinc-500">QR successes</p>
+                      <p className="text-xl font-semibold">{agentScanStats.successfulQrScans}</p>
+                    </div>
+                  </div>
+                ) : null}
+
+                {selectedAgentId ? (
+                  <div className="mt-4">
+                    {agentScanLoading ? (
+                      <p className="text-sm text-zinc-500">Loading scan history…</p>
+                    ) : agentScanHistory.length === 0 ? (
+                      <p className="text-sm text-zinc-500">No scan logs found for this agent.</p>
+                    ) : (
+                      <div className="space-y-2">
+                        {agentScanHistory.map((log) => (
+                          <div
+                            key={log._id}
+                            className={`rounded-lg p-3 text-sm flex justify-between items-center ${
+                              log.scanStatus === "success"
+                                ? "bg-green-50"
+                                : log.scanStatus === "already_scanned"
+                                ? "bg-yellow-50"
+                                : "bg-red-50"
+                            }`}
+                          >
+                            <div className="min-w-0">
+                              <p className="font-medium truncate">{log.name}</p>
+                              <p className="text-xs text-zinc-600 truncate">{log.email}</p>
+                              <p className="text-xs text-zinc-600">
+                                {(log.sessionType || "").replace("-", " ")}
+                                {log.sessionType ? " • " : ""}
+                                {renderSourceBadge(log.scanSource)}
+                              </p>
+                              <p className="text-xs text-zinc-500">{formatDateTime(log.scannedAt)}</p>
+                              {log.scanStatus !== "success" && log.message ? (
+                                <p className="text-xs text-zinc-600">{log.message}</p>
+                              ) : null}
+                            </div>
+
+                            <span
+                              className={`ml-3 shrink-0 px-2 py-1 rounded-full text-xs ${
+                                log.scanStatus === "success"
+                                  ? "bg-green-200 text-green-800"
+                                  : log.scanStatus === "already_scanned"
+                                  ? "bg-yellow-200 text-yellow-800"
+                                  : "bg-red-200 text-red-800"
+                              }`}
+                            >
+                              {log.scanStatus === "success" ? "Success" : log.scanStatus === "already_scanned" ? "Already" : "Invalid"}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ) : null}
               </div>
 
               <div>

--- a/client/app/agent/dashboard/page.tsx
+++ b/client/app/agent/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import Logo from "@/components/Logo"
 import { scanApi } from "@/lib/api"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog"
+import { ConfirmDialog } from "@/components/ui/confirm-dialog"
 import { BrowserQRCodeReader, IScannerControls } from "@zxing/browser"
 import { Result, Exception } from "@zxing/library"
 
@@ -18,9 +19,26 @@ type ScanResult = {
   ticketType: string
   status: "success" | "already_scanned" | "invalid"
   scannedAt: string
+  message?: string
+  scanSource?: "qr" | "manual"
   scannedBy?: string
   checkedInAt?: string
   sessionType?: string
+}
+
+type Attendee = {
+  _id: string
+  name?: string
+  email?: string
+  ticketType?: string
+  qrCode?: string
+  preConferenceQrCode?: string
+  mainConferenceQrCode?: string
+  checkInStatus?: "checked-in" | "not-checked-in"
+  preConferenceCheckInStatus?: "checked-in" | "not-checked-in"
+  mainConferenceCheckInStatus?: "checked-in" | "not-checked-in"
+  preConferenceCheckInSource?: "qr" | "manual"
+  mainConferenceCheckInSource?: "qr" | "manual"
 }
 
 export default function AgentDashboardPage() {
@@ -29,14 +47,50 @@ export default function AgentDashboardPage() {
   const [scanning, setScanning] = useState(false)
   const [lastResult, setLastResult] = useState<ScanResult | null>(null)
   const [scanHistory, setScanHistory] = useState<ScanResult[]>([])
-  const [stats, setStats] = useState({ totalScans: 0, successfulCheckIns: 0 })
+  const [stats, setStats] = useState({ totalScans: 0, successfulCheckIns: 0, successfulManualCheckIns: 0 })
   const [showHistory, setShowHistory] = useState(false)
   const [isScannerOpen, setIsScannerOpen] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
+  // Registered attendees (manual check-in UI)
+  const [attendees, setAttendees] = useState<Attendee[]>([])
+  const [attendeesLoading, setAttendeesLoading] = useState(false)
+  const [attendeesError, setAttendeesError] = useState<string | null>(null)
+
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const [confirmSession, setConfirmSession] = useState<"pre-conference" | "main-conference">("main-conference")
+  const [confirmAttendee, setConfirmAttendee] = useState<Attendee | null>(null)
+  const [confirmLoading, setConfirmLoading] = useState(false)
+  const [confirmError, setConfirmError] = useState<string | null>(null)
+
   // QR Scanner refs
   const videoRef = useRef<HTMLVideoElement>(null)
   const controlsRef = useRef<IScannerControls | null>(null)
+
+  const formatDateTime = useCallback((iso: string) => {
+    const date = new Date(iso)
+    if (Number.isNaN(date.getTime())) return ""
+    return new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(date)
+  }, [])
+
+  const renderSourceBadge = useCallback((source?: "qr" | "manual") => {
+    if (!source) return null
+    const isManual = source === "manual"
+    return (
+      <span
+        className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-medium ${
+          isManual ? "bg-indigo-100 text-indigo-800" : "bg-emerald-100 text-emerald-800"
+        }`}
+      >
+        {isManual ? "Manual" : "QR"}
+      </span>
+    )
+  }, [])
 
   // Check auth on mount
   useEffect(() => {
@@ -62,10 +116,18 @@ export default function AgentDashboardPage() {
         attendeeName: item.name || "Unknown",
         email: item.email || "",
         ticketType: item.ticketType || "",
-        status: item.checkInStatus === "checked-in" ? "success" : "invalid", // The backend now sends the correct status for the session
-        scannedAt: item.checkedInAt,
-        scannedBy: item.checkedInBy?.name,
-        sessionType: item.sessionType, // This now comes directly from the backend
+        status: item.scanStatus || (item.checkInStatus === "checked-in" ? "success" : "invalid"),
+        scannedAt: item.scannedAt || item.checkedInAt || new Date().toISOString(),
+        message: item.message,
+        scanSource: item.scanSource,
+        scannedBy: item.details?.checkedInBy,
+        checkedInAt: item.details?.checkedInAt,
+        sessionType:
+          item.sessionType === "pre-conference"
+            ? "Pre-Conference"
+            : item.sessionType === "main-conference"
+              ? "Main Conference"
+              : item.sessionType,
       }))
       setScanHistory(formattedHistory)
       setStats(stats)
@@ -74,12 +136,60 @@ export default function AgentDashboardPage() {
     }
   }, [])
 
+  const fetchAttendees = useCallback(async () => {
+    setAttendeesLoading(true)
+    setAttendeesError(null)
+    try {
+      const res = await scanApi.getAttendees()
+      const list = (res?.data ?? res) as Attendee[]
+      setAttendees(Array.isArray(list) ? list : [])
+    } catch (error) {
+      console.error("Failed to fetch attendees:", error)
+      setAttendeesError("Failed to load registered people")
+    } finally {
+      setAttendeesLoading(false)
+    }
+  }, [])
+
   // Load scan history from server on initial load
   useEffect(() => {
     if (user && user.role === "agent") {
       fetchScanHistory()
+      fetchAttendees()
     }
-  }, [user, fetchScanHistory])
+  }, [user, fetchScanHistory, fetchAttendees])
+
+  const openManualConfirm = useCallback(
+    (session: "pre-conference" | "main-conference", attendee: Attendee) => {
+      setConfirmSession(session)
+      setConfirmAttendee(attendee)
+      setConfirmError(null)
+      setConfirmOpen(true)
+    },
+    []
+  )
+
+  const doManualCheckIn = useCallback(async () => {
+    if (!confirmAttendee?._id) return
+    setConfirmLoading(true)
+    setConfirmError(null)
+    try {
+      if (confirmSession === "pre-conference") {
+        await scanApi.manualCheckInPreConference(confirmAttendee._id)
+      } else {
+        await scanApi.manualCheckInMainConference(confirmAttendee._id)
+      }
+      setConfirmOpen(false)
+      setConfirmAttendee(null)
+      await fetchAttendees()
+      await fetchScanHistory()
+    } catch (err: any) {
+      const msg = err?.response?.data?.message || "Manual check-in failed"
+      setConfirmError(String(msg))
+    } finally {
+      setConfirmLoading(false)
+    }
+  }, [confirmAttendee, confirmSession, fetchAttendees, fetchScanHistory])
 
   // Scan handler for camera scan
   const handleCameraScan = useCallback(async (token: string) => {
@@ -106,10 +216,12 @@ export default function AgentDashboardPage() {
       let checkedInAtTime: string | undefined = undefined
       let attendeeName: string | undefined = undefined
       let sessionType: string | undefined = undefined
+      let message: string | undefined = undefined
 
       if (err.response && err.response.data) {
-        const { message, details } = err.response.data;
-        const msg = (message as string).toLowerCase();
+        const { message: serverMessage, details } = err.response.data;
+        message = serverMessage as string
+        const msg = (serverMessage as string).toLowerCase();
 
         if (msg.includes("already") || msg.includes("used")) {
           status = "already_scanned"
@@ -129,6 +241,7 @@ export default function AgentDashboardPage() {
         ticketType: "",
         status,
         scannedAt: new Date().toISOString(),
+        message,
         scannedBy: scannedByAgent,
         checkedInAt: checkedInAtTime,
         sessionType,
@@ -226,8 +339,48 @@ export default function AgentDashboardPage() {
         </DialogContent>
       </Dialog>
 
+      <ConfirmDialog
+        open={confirmOpen}
+        title={
+          confirmSession === "pre-conference"
+            ? "Confirm Pre-Conference Manual Check-in"
+            : "Confirm Main Conference Manual Check-in"
+        }
+        description={
+          <div className="space-y-2">
+            <p className="text-zinc-700">
+              You are about to manually check in:
+              <span className="font-semibold"> {confirmAttendee?.name || "Unknown"}</span>
+            </p>
+            <p className="text-zinc-600">
+              <span className="font-medium">Email:</span> {confirmAttendee?.email || "—"}
+            </p>
+            <p className="text-zinc-600">
+              <span className="font-medium">Ticket:</span> {confirmAttendee?.ticketType || "—"}
+            </p>
+            <p className="text-sm text-red-600">
+              This action is not reversible. Please confirm you’re checking in the correct person.
+            </p>
+            {confirmError ? (
+              <p className="text-sm text-red-600">{confirmError}</p>
+            ) : null}
+          </div>
+        }
+        confirmText={confirmSession === "pre-conference" ? "Check in (Pre-Conf)" : "Check in (Main Conf)"}
+        cancelText="Cancel"
+        variant="danger"
+        loading={confirmLoading}
+        onConfirm={doManualCheckIn}
+        onCancel={() => {
+          if (confirmLoading) return
+          setConfirmOpen(false)
+          setConfirmAttendee(null)
+          setConfirmError(null)
+        }}
+      />
+
       <div className="max-w-4xl mx-auto px-4 py-8">
-        <div className="grid grid-cols-2 gap-4 mb-6">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
           <div className="bg-white rounded-xl p-4 shadow text-center">
             <p className="text-3xl font-bold text-green-600">{stats.successfulCheckIns}</p>
             <p className="text-sm text-zinc-500">Successful Check-ins</p>
@@ -235,6 +388,10 @@ export default function AgentDashboardPage() {
           <div className="bg-white rounded-xl p-4 shadow text-center">
             <p className="text-3xl font-bold text-zinc-900">{stats.totalScans}</p>
             <p className="text-sm text-zinc-500">Total Scans</p>
+          </div>
+          <div className="bg-white rounded-xl p-4 shadow text-center">
+            <p className="text-3xl font-bold text-purple-700">{stats.successfulManualCheckIns}</p>
+            <p className="text-sm text-zinc-500">Manual Check-ins</p>
           </div>
         </div>
 
@@ -296,8 +453,10 @@ export default function AgentDashboardPage() {
               {lastResult.status === "invalid" && (
                 <>
                   <div className="text-6xl mb-2">❌</div>
-                  <h3 className="text-2xl font-bold text-red-700">Invalid QR Code</h3>
-                  <p className="text-sm text-red-500 mt-2">This QR code is not recognized</p>
+                  <h3 className="text-2xl font-bold text-red-700">Scan Failed</h3>
+                  <p className="text-sm text-red-500 mt-2">
+                    {lastResult.message || "This QR code is not recognized"}
+                  </p>
                 </>
               )}
             </div>
@@ -335,14 +494,18 @@ export default function AgentDashboardPage() {
                 <div>
       <p className="font-medium">{scan.attendeeName}</p>
       {scan.sessionType && (
-        <p className="text-xs text-zinc-600">{scan.sessionType}</p>
+        <p className="text-xs text-zinc-600">
+          {scan.sessionType}{scan.scanSource ? ` • ${scan.scanSource === "manual" ? "Manual" : "QR"}` : ""}
+        </p>
       )}
-      <p className="text-xs text-zinc-500">
-        {new Date(scan.scannedAt).toLocaleTimeString([], {
-          hour: '2-digit',
-          minute: '2-digit',
-        })}
-      </p>
+      <p className="text-xs text-zinc-500">{formatDateTime(scan.scannedAt)}</p>
+      {scan.status !== "success" && (scan.message || scan.scannedBy || scan.checkedInAt) ? (
+        <p className="text-xs text-zinc-600">
+          {scan.message || ""}
+          {scan.scannedBy ? ` • Checked in by: ${scan.scannedBy}` : ""}
+          {scan.checkedInAt ? ` • At: ${formatDateTime(scan.checkedInAt)}` : ""}
+        </p>
+      ) : null}
     </div>
 
                 <span
@@ -360,6 +523,100 @@ export default function AgentDashboardPage() {
             ))}
           </div>
         )}
+
+        {/* Registered People */}
+        <div className="mt-8">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-lg font-semibold text-zinc-900">Registered People</h2>
+            <Button variant="outline" onClick={fetchAttendees} disabled={attendeesLoading}>
+              Refresh
+            </Button>
+          </div>
+
+          {attendeesError ? (
+            <div className="bg-red-50 border border-red-200 text-red-700 rounded-xl p-3 text-sm">
+              {attendeesError}
+            </div>
+          ) : null}
+
+          <div className="bg-white rounded-2xl shadow p-4 overflow-x-auto">
+            {attendeesLoading ? (
+              <div className="text-sm text-zinc-500">Loading registered people…</div>
+            ) : attendees.length === 0 ? (
+              <div className="text-sm text-zinc-500">No attendees found.</div>
+            ) : (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b bg-zinc-50">
+                    <th className="text-left p-3">Name</th>
+                    <th className="text-left p-3">Email</th>
+                    <th className="text-left p-3">Ticket</th>
+                    <th className="text-center p-3">Pre-Conf</th>
+                    <th className="text-center p-3">Main Conf</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {attendees.map((a) => {
+                    const eligibleForPreConf = Boolean(a.preConferenceQrCode)
+                    const preConfCheckedIn = a.preConferenceCheckInStatus === "checked-in"
+
+                    const eligibleForMainConf = Boolean(a.qrCode || a.mainConferenceQrCode)
+                    const mainCheckedIn =
+                      a.mainConferenceQrCode
+                        ? a.mainConferenceCheckInStatus === "checked-in"
+                        : a.checkInStatus === "checked-in"
+
+                    return (
+                      <tr key={a._id} className="border-b hover:bg-zinc-50">
+                        <td className="p-3">{a.name || "Unknown"}</td>
+                        <td className="p-3 text-zinc-500">{a.email || ""}</td>
+                        <td className="p-3">{a.ticketType || ""}</td>
+
+                        <td className="p-3 text-center">
+                          {!eligibleForPreConf ? (
+                            <span className="text-zinc-400">N/A</span>
+                          ) : preConfCheckedIn ? (
+                            <div className="inline-flex flex-col items-center gap-1">
+                              <span>✅</span>
+                              {renderSourceBadge(a.preConferenceCheckInSource)}
+                            </div>
+                          ) : (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => openManualConfirm("pre-conference", a)}
+                            >
+                              Check in
+                            </Button>
+                          )}
+                        </td>
+
+                        <td className="p-3 text-center">
+                          {!eligibleForMainConf ? (
+                            <span className="text-zinc-400">N/A</span>
+                          ) : mainCheckedIn ? (
+                            <div className="inline-flex flex-col items-center gap-1">
+                              <span>✅</span>
+                              {renderSourceBadge(a.mainConferenceCheckInSource)}
+                            </div>
+                          ) : (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => openManualConfirm("main-conference", a)}
+                            >
+                              Check in
+                            </Button>
+                          )}
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/client/app/agent/dashboard/page.tsx
+++ b/client/app/agent/dashboard/page.tsx
@@ -26,6 +26,37 @@ type ScanResult = {
   sessionType?: string
 }
 
+type ScanHistoryApiItem = {
+  _id: string
+  name?: string
+  email?: string
+  ticketType?: string
+  scanStatus?: "success" | "already_scanned" | "invalid"
+  scanSource?: "qr" | "manual"
+  scannedAt?: string
+  checkedInAt?: string
+  checkInStatus?: "checked-in" | "not-checked-in"
+  message?: string
+  details?: {
+    checkedInBy?: string
+    checkedInAt?: string
+    sessionType?: string
+  }
+  sessionType?: string
+}
+
+type ScanErrorDetails = {
+  attendeeName?: string
+  checkedInBy?: string
+  checkedInAt?: string
+  sessionType?: string
+}
+
+type ErrorPayload = {
+  message?: string
+  details?: ScanErrorDetails
+}
+
 type Attendee = {
   _id: string
   name?: string
@@ -44,7 +75,6 @@ type Attendee = {
 export default function AgentDashboardPage() {
   const router = useRouter()
   const { user, logout } = useAuth()
-  const [scanning, setScanning] = useState(false)
   const [lastResult, setLastResult] = useState<ScanResult | null>(null)
   const [scanHistory, setScanHistory] = useState<ScanResult[]>([])
   const [stats, setStats] = useState({ totalScans: 0, successfulCheckIns: 0, successfulManualCheckIns: 0 })
@@ -92,6 +122,20 @@ export default function AgentDashboardPage() {
     )
   }, [])
 
+  const getErrorPayload = useCallback((err: unknown): ErrorPayload | null => {
+    if (!err || typeof err !== "object") return null
+    if (!("response" in err)) return null
+    const response = (err as { response?: { data?: unknown } }).response
+    if (!response || typeof response.data !== "object" || !response.data) return null
+    const data = response.data as { message?: unknown; details?: unknown }
+    const message = typeof data.message === "string" ? data.message : undefined
+    const details =
+      data.details && typeof data.details === "object"
+        ? (data.details as ScanErrorDetails)
+        : undefined
+    return { message, details }
+  }, [])
+
   // Check auth on mount
   useEffect(() => {
     if (!user || user.role !== "agent") {
@@ -109,9 +153,14 @@ export default function AgentDashboardPage() {
   const fetchScanHistory = useCallback(async () => {
     try {
       const response = await scanApi.getScanHistory()
-      const { history, stats } = response.data
+      const payload = (response?.data ?? response) as {
+        history?: ScanHistoryApiItem[]
+        stats?: { totalScans: number; successfulCheckIns: number; successfulManualCheckIns?: number }
+      }
+      const history = Array.isArray(payload?.history) ? payload.history : []
+      const stats = payload?.stats ?? { totalScans: 0, successfulCheckIns: 0, successfulManualCheckIns: 0 }
       
-      const formattedHistory: ScanResult[] = history.map((item: any) => ({
+      const formattedHistory: ScanResult[] = history.map((item) => ({
         id: item._id,
         attendeeName: item.name || "Unknown",
         email: item.email || "",
@@ -130,7 +179,11 @@ export default function AgentDashboardPage() {
               : item.sessionType,
       }))
       setScanHistory(formattedHistory)
-      setStats(stats)
+      setStats({
+        totalScans: stats.totalScans,
+        successfulCheckIns: stats.successfulCheckIns,
+        successfulManualCheckIns: stats.successfulManualCheckIns ?? 0,
+      })
     } catch (error) {
       console.error("Failed to fetch scan history:", error)
     }
@@ -183,18 +236,18 @@ export default function AgentDashboardPage() {
       setConfirmAttendee(null)
       await fetchAttendees()
       await fetchScanHistory()
-    } catch (err: any) {
-      const msg = err?.response?.data?.message || "Manual check-in failed"
-      setConfirmError(String(msg))
+    } catch (err: unknown) {
+      const payload = getErrorPayload(err)
+      const msg = payload?.message || "Manual check-in failed"
+      setConfirmError(msg)
     } finally {
       setConfirmLoading(false)
     }
-  }, [confirmAttendee, confirmSession, fetchAttendees, fetchScanHistory])
+  }, [confirmAttendee, confirmSession, fetchAttendees, fetchScanHistory, getErrorPayload])
 
   // Scan handler for camera scan
   const handleCameraScan = useCallback(async (token: string) => {
     setIsScannerOpen(false)
-    setScanning(true)
 
     try {
       const res = await scanApi.scanQR(token)
@@ -210,7 +263,7 @@ export default function AgentDashboardPage() {
         sessionType: data?.sessionType || "",
       }
       setLastResult(result)
-    } catch (err: any) {
+    } catch (err: unknown) {
       let status: "already_scanned" | "invalid" = "invalid"
       let scannedByAgent: string | undefined = undefined
       let checkedInAtTime: string | undefined = undefined
@@ -218,18 +271,18 @@ export default function AgentDashboardPage() {
       let sessionType: string | undefined = undefined
       let message: string | undefined = undefined
 
-      if (err.response && err.response.data) {
-        const { message: serverMessage, details } = err.response.data;
-        message = serverMessage as string
-        const msg = (serverMessage as string).toLowerCase();
+      const payload = getErrorPayload(err)
+      if (payload?.message) {
+        message = payload.message
+        const msg = payload.message.toLowerCase()
 
         if (msg.includes("already") || msg.includes("used")) {
           status = "already_scanned"
-          if (details) {
-            attendeeName = details.attendeeName
-            scannedByAgent = details.checkedInBy
-            checkedInAtTime = details.checkedInAt
-            sessionType = details.sessionType
+          if (payload.details) {
+            attendeeName = payload.details.attendeeName
+            scannedByAgent = payload.details.checkedInBy
+            checkedInAtTime = payload.details.checkedInAt
+            sessionType = payload.details.sessionType
           }
         }
       }
@@ -248,11 +301,10 @@ export default function AgentDashboardPage() {
       }
       setLastResult(result)
     } finally {
-      setScanning(false)
       // Always re-fetch history to get the authoritative state from the server
       fetchScanHistory()
     }
-  }, [fetchScanHistory])
+  }, [fetchScanHistory, getErrorPayload])
 
   useEffect(() => {
     if (!isScannerOpen) {

--- a/client/app/login/page.tsx
+++ b/client/app/login/page.tsx
@@ -21,22 +21,21 @@ export default function LoginPage() {
 
   try {
     await login({ email, password })
-  } catch (err: any) {
+  } catch (err: unknown) {
     let message = "Login failed. Please check your email and password."
 
-    if (err?.response) {
-      if (err.response.status === 400 || err.response.status === 401) {
-        message = "Invalid email or password."
-      } 
-      else if (err.response.status === 404) {
-        message = "Account not found."
-      } 
-      else if (err.response.status >= 500) {
-        message = "Server error. Please try again later."
-      }
-    } 
-    
-    else if (err?.message?.includes("Network")) {
+    const status =
+      typeof err === "object" && err && "response" in err
+        ? (err as { response?: { status?: number } }).response?.status
+        : undefined
+
+    if (status === 400 || status === 401) {
+      message = "Invalid email or password."
+    } else if (status === 404) {
+      message = "Account not found."
+    } else if (typeof status === "number" && status >= 500) {
+      message = "Server error. Please try again later."
+    } else if (err instanceof Error && err.message.includes("Network")) {
       message = "Network error. Please check your connection."
     }
 

--- a/client/components/form/FileField.tsx
+++ b/client/components/form/FileField.tsx
@@ -1,5 +1,6 @@
 "use client"
-import React, { useCallback, useEffect, useRef, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import Image from "next/image"
 import { cn } from "@/lib/utils"
 
 type Props = {
@@ -12,20 +13,14 @@ type Props = {
 
 export default function FileField({ label, name, value, onChange, required }: Props) {
   const [isDragging, setIsDragging] = useState(false)
-  const [preview, setPreview] = useState<string | null>(null)
   const inputRef = useRef<HTMLInputElement | null>(null)
 
+  const preview = useMemo(() => (value ? URL.createObjectURL(value) : null), [value])
+
   useEffect(() => {
-    if (value) {
-      const reader = new FileReader()
-      reader.onloadend = () => {
-        setPreview(reader.result as string)
-      }
-      reader.readAsDataURL(value)
-    } else {
-      setPreview(null)
-    }
-  }, [value])
+    if (!preview) return
+    return () => URL.revokeObjectURL(preview)
+  }, [preview])
 
   const pickFile = () => inputRef.current?.click()
 
@@ -142,17 +137,20 @@ export default function FileField({ label, name, value, onChange, required }: Pr
       {preview && (
         <div className="mt-4 w-full max-w-xs relative">
           {/* Preview Image */}
-          <img
-            src={preview}
-            alt="Preview"
-            className="w-full rounded-xl border shadow-md"
-          />
+          <div className="relative w-full aspect-[4/3]">
+            <Image
+              src={preview}
+              alt="Preview"
+              fill
+              sizes="(max-width: 640px) 100vw, 320px"
+              className="rounded-xl border shadow-md object-cover"
+            />
+          </div>
 
           {/* X Remove Button */}
           <button
             type="button"
             onClick={() => {
-              setPreview(null)
               onChange(null)
               if (inputRef.current) inputRef.current.value = ""
             }}

--- a/client/lib/api.ts
+++ b/client/lib/api.ts
@@ -227,6 +227,10 @@ export const adminApi = {
   createAgent: async (data: { name: string; email: string }) =>
     (await api.post("/admin/agents", data)).data,
   getAgents: async () => (await api.get("/admin/agents")).data,
+  getAgentScanHistory: async (agentId: string, limit?: number) => {
+    const qs = typeof limit === "number" ? `?limit=${encodeURIComponent(String(limit))}` : "";
+    return (await api.get(`/admin/agents/${agentId}/scan-history${qs}`)).data;
+  },
   manualRegister: async (data: Record<string, unknown>) =>
     (await api.post("/admin/attendees/manual", data)).data,
   inviteAttendee: async (data: Record<string, unknown>) =>
@@ -261,11 +265,25 @@ export const adminApi = {
     ticketType: string;
     sessionType?: 'pre-conference' | 'main-conference';
   }) => (await api.post("/admin/attendees/instant-checkin", data)).data,
+
+  manualCheckInPreConference: async (attendeeId: string) =>
+    (await api.post("/admin/attendees/pre-conference/manual-check-in", { attendeeId })).data,
+  manualCheckInMainConference: async (attendeeId: string) =>
+    (await api.post("/admin/attendees/main-conference/manual-check-in", { attendeeId })).data,
 };
 
 // Scan API
 export const scanApi = {
   scanQR: async (qrCode: string) => (await api.post("/scan", { qrCode })).data,
+  checkInPreConference: async (qrCode: string) =>
+    (await api.post("/scan/pre-conference/check-in", { qrCode })).data,
+  checkInMainConference: async (qrCode: string) =>
+    (await api.post("/scan/main-conference/check-in", { qrCode })).data,
+  getAttendees: async () => (await api.get("/scan/attendees")).data,
+  manualCheckInPreConference: async (attendeeId: string) =>
+    (await api.post("/scan/pre-conference/manual-check-in", { attendeeId })).data,
+  manualCheckInMainConference: async (attendeeId: string) =>
+    (await api.post("/scan/main-conference/manual-check-in", { attendeeId })).data,
   getScanHistory: async () => (await api.get("/scan/history")).data,
 };
 

--- a/server/src/controllers/admin.controller.ts
+++ b/server/src/controllers/admin.controller.ts
@@ -14,6 +14,8 @@ import {
   ForbiddenError,
 } from '../utils/customErrors';
 import { AuthenticatedRequest } from '../middleware/auth.middleware';
+import { recordScanAttempt } from '../services/scanHistory.service';
+import { getLatestSuccessfulCheckInSourcesForAttendees } from '../services/scanHistory.service';
 import passwordGenerator from '../utils/passwordGenerator';
 import emailService from '../services/email.service';
 import { generateQRCode } from '../services/qr.service';
@@ -484,10 +486,24 @@ class AdminController {
         createdAt: -1,
       });
 
+      const attendeeIds = attendees.map((a) => a._id);
+      const sourcesMap = await getLatestSuccessfulCheckInSourcesForAttendees(attendeeIds);
+      const enriched = attendees.map((a) => {
+        const obj = a.toObject();
+        const id = a._id.toString();
+        const pre = sourcesMap.get(`${id}:pre-conference`);
+        const main = sourcesMap.get(`${id}:main-conference`);
+        return {
+          ...obj,
+          preConferenceCheckInSource: pre?.scanSource,
+          mainConferenceCheckInSource: main?.scanSource,
+        };
+      });
+
       res.status(200).json({
         success: true,
-        count: attendees.length,
-        data: attendees,
+        count: enriched.length,
+        data: enriched,
       });
     }
   );
@@ -697,6 +713,158 @@ class AdminController {
       res.status(201).json({
         success: true,
         message: 'Attendee registered and checked in successfully.',
+        data: attendee,
+      });
+    }
+  );
+
+  manualCheckInPreConference = asyncHandler(
+    async (req: AuthenticatedRequest, res: Response) => {
+      const { attendeeId } = req.body as { attendeeId?: string };
+
+      if (req.user?.role !== UserRole.ADMIN) {
+        throw new ForbiddenError('Only administrators can check in attendees.');
+      }
+
+      if (!attendeeId) {
+        throw new BadRequestError('attendeeId is required.');
+      }
+
+      const attendee = await User.findById(attendeeId).populate(
+        'preConferenceCheckedInBy',
+        'name'
+      );
+
+      if (!attendee) {
+        throw new NotFoundError('Attendee not found.');
+      }
+
+      if (attendee.role !== UserRole.USER) {
+        throw new BadRequestError('Only attendees can be checked in.');
+      }
+
+      if (!attendee.preConferenceQrCode) {
+        throw new BadRequestError(
+          'This attendee does not have a pre-conference ticket.'
+        );
+      }
+
+      if (attendee.preConferenceCheckInStatus === CheckInStatus.CHECKED_IN) {
+        throw new BadRequestError('This pre-conference ticket has already been used.');
+      }
+
+      attendee.preConferenceCheckInStatus = CheckInStatus.CHECKED_IN;
+      attendee.preConferenceCheckedInAt = new Date();
+      attendee.preConferenceCheckedInBy = req.user._id as any;
+      await attendee.save();
+
+      await recordScanAttempt({
+        agentId: req.user._id,
+        scanSource: 'manual',
+        scanStatus: 'success',
+        sessionType: 'pre-conference',
+        attendee,
+        message: 'Pre-conference check-in successful.',
+      });
+
+      res.status(200).json({
+        success: true,
+        message: 'Pre-conference check-in successful.',
+        data: attendee,
+      });
+    }
+  );
+
+  manualCheckInMainConference = asyncHandler(
+    async (req: AuthenticatedRequest, res: Response) => {
+      const { attendeeId } = req.body as { attendeeId?: string };
+
+      if (req.user?.role !== UserRole.ADMIN) {
+        throw new ForbiddenError('Only administrators can check in attendees.');
+      }
+
+      if (!attendeeId) {
+        throw new BadRequestError('attendeeId is required.');
+      }
+
+      const attendee = await User.findById(attendeeId).populate(
+        'checkedInBy mainConferenceCheckedInBy',
+        'name'
+      );
+
+      if (!attendee) {
+        throw new NotFoundError('Attendee not found.');
+      }
+
+      if (attendee.role !== UserRole.USER) {
+        throw new BadRequestError('Only attendees can be checked in.');
+      }
+
+      const isLegacyTicket =
+        !attendee.mainConferenceQrCode &&
+        !attendee.preConferenceQrCode &&
+        attendee.qrCode;
+
+      if (isLegacyTicket) {
+        if (attendee.checkInStatus === CheckInStatus.CHECKED_IN) {
+          throw new BadRequestError('This ticket has already been used.');
+        }
+
+        attendee.checkInStatus = CheckInStatus.CHECKED_IN;
+        attendee.checkedInAt = new Date();
+        attendee.checkedInBy = req.user._id as any;
+        await attendee.save();
+
+        await recordScanAttempt({
+          agentId: req.user._id,
+          scanSource: 'manual',
+          scanStatus: 'success',
+          sessionType: 'main-conference',
+          attendee,
+          message: 'Check-in successful.',
+        });
+
+        res.status(200).json({
+          success: true,
+          message: 'Check-in successful.',
+          data: attendee,
+        });
+        return;
+      }
+
+      const checkedInField =
+        attendee.ticketType === TicketType.LECTURER_PREMIUM
+          ? attendee.mainConferenceCheckInStatus
+          : attendee.checkInStatus;
+
+      if (checkedInField === CheckInStatus.CHECKED_IN) {
+        throw new BadRequestError('This ticket has already been used.');
+      }
+
+      if (attendee.ticketType === TicketType.LECTURER_PREMIUM) {
+        attendee.mainConferenceCheckInStatus = CheckInStatus.CHECKED_IN;
+        attendee.mainConferenceCheckedInAt = new Date();
+        attendee.mainConferenceCheckedInBy = req.user._id as any;
+      } else {
+        attendee.checkInStatus = CheckInStatus.CHECKED_IN;
+        attendee.checkedInAt = new Date();
+        attendee.checkedInBy = req.user._id as any;
+      }
+
+      await attendee.save();
+
+      await recordScanAttempt({
+        agentId: req.user._id,
+        scanSource: 'manual',
+        scanStatus: 'success',
+        sessionType: 'main-conference',
+        attendee,
+        message: 'Check-in successful.',
+      });
+
+      res.status(200).json({
+        success: true,
+        message: 'Check-in successful.',
         data: attendee,
       });
     }

--- a/server/src/controllers/scan.controller.ts
+++ b/server/src/controllers/scan.controller.ts
@@ -10,17 +10,27 @@ import {
 import { AuthenticatedRequest } from '../middleware/auth.middleware';
 import logger from '../utils/logger';
 import { verifyQRCode } from '../services/qr.service';
+import {
+  getAgentScanHistoryData,
+  getLatestSuccessfulCheckInSourcesForAttendees,
+  recordScanAttempt,
+} from '../services/scanHistory.service';
 
 class ScanController {
-  // server/src/controllers/scan.controller.ts - UPDATED VERSION
+  private processQRCodeCheckIn = async (
+    req: AuthenticatedRequest,
+    res: Response,
+    forcedSessionType?: 'pre-conference' | 'main-conference'
+  ) => {
+    const agent = req.user;
+    const { qrCode } = req.body;
 
-  scanQRCode = asyncHandler(
-    async (req: AuthenticatedRequest, res: Response) => {
-      const agent = req.user;
-      const { qrCode } = req.body;
+    let sessionTypeForLog: 'pre-conference' | 'main-conference' | undefined = forcedSessionType;
+    let attendeeForLog: any = undefined;
 
+    try {
       if (agent?.role !== UserRole.AGENT) {
-        throw new ForbiddenError('Only agents can scan QR codes.');
+        throw new ForbiddenError('Only agents can check in attendees.');
       }
 
       if (!qrCode) {
@@ -32,26 +42,41 @@ class ScanController {
         throw new BadRequestError('Invalid or expired QR code.');
       }
 
-      // Default to main-conference for backward compatibility
-      const sessionType = decoded.sessionType || 'main-conference';
+      const decodedSessionType: 'pre-conference' | 'main-conference' =
+        decoded.sessionType || 'main-conference';
+
+      if (forcedSessionType && decodedSessionType !== forcedSessionType) {
+        sessionTypeForLog = decodedSessionType;
+        throw new BadRequestError(
+          `This QR code is for ${decodedSessionType.replace('-', ' ')}. Please scan the correct ticket.`
+        );
+      }
+
+      const sessionType = forcedSessionType || decodedSessionType;
+      sessionTypeForLog = sessionType;
 
       const attendee = await User.findOne({ email: decoded.email }).populate(
         'checkedInBy preConferenceCheckedInBy mainConferenceCheckedInBy',
         'name'
       );
+      attendeeForLog = attendee;
 
       if (!attendee) {
         throw new NotFoundError('Invalid QR code. Attendee not found.');
       }
 
-      // NEW: Handle old tickets (users without new fields)
       const isLegacyTicket =
         !attendee.mainConferenceQrCode &&
         !attendee.preConferenceQrCode &&
-        attendee.qrCode; // Has old qrCode field
+        attendee.qrCode;
 
       if (isLegacyTicket) {
-        // Use old check-in logic for backward compatibility
+        if (sessionType === 'pre-conference') {
+          throw new BadRequestError(
+            'This attendee does not have a pre-conference ticket.'
+          );
+        }
+
         if (attendee.checkInStatus === CheckInStatus.CHECKED_IN) {
           throw new ConflictError('This ticket has already been used.', {
             attendeeName: attendee.name,
@@ -66,9 +91,17 @@ class ScanController {
         attendee.checkedInBy = agent._id as any;
         await attendee.save();
 
-        logger.info(
-          `Agent ${agent.email} checked in legacy ticket for attendee ${attendee.email}`
-        );
+        await recordScanAttempt({
+          agentId: agent._id,
+          scanSource: 'qr',
+          scanStatus: 'success',
+          sessionType: sessionTypeForLog,
+          attendee,
+          message: 'Check-in successful.',
+          qrCode,
+        });
+
+        logger.info(`Agent ${agent.email} checked in legacy ticket for attendee ${attendee.email}`);
 
         res.status(200).json({
           success: true,
@@ -80,10 +113,9 @@ class ScanController {
             sessionType: 'Main Conference (January 21)',
           },
         });
-        return; // Exit early for legacy tickets
+        return;
       }
 
-      // Handle session-specific check-in for new tickets
       if (sessionType === 'pre-conference') {
         if (!attendee.preConferenceQrCode) {
           throw new BadRequestError(
@@ -108,9 +140,17 @@ class ScanController {
         attendee.preConferenceCheckedInBy = agent._id as any;
         await attendee.save();
 
-        logger.info(
-          `Agent ${agent.email} checked in attendee ${attendee.email} for pre-conference`
-        );
+        await recordScanAttempt({
+          agentId: agent._id,
+          scanSource: 'qr',
+          scanStatus: 'success',
+          sessionType: sessionTypeForLog,
+          attendee,
+          message: 'Pre-conference check-in successful.',
+          qrCode,
+        });
+
+        logger.info(`Agent ${agent.email} checked in attendee ${attendee.email} for pre-conference`);
 
         res.status(200).json({
           success: true,
@@ -122,53 +162,187 @@ class ScanController {
             sessionType: 'Pre-Conference (January 20)',
           },
         });
+        return;
+      }
+
+      const checkedInField = attendee.ticketType === TicketType.LECTURER_PREMIUM ? attendee.mainConferenceCheckInStatus : attendee.checkInStatus;
+
+      if (checkedInField === CheckInStatus.CHECKED_IN) {
+        const checkedInBy = attendee.ticketType === TicketType.LECTURER_PREMIUM ? (attendee.mainConferenceCheckedInBy as any)?.name : (attendee.checkedInBy as any)?.name;
+
+        const checkedInAt = attendee.ticketType === TicketType.LECTURER_PREMIUM ? attendee.mainConferenceCheckedInAt : attendee.checkedInAt;
+
+        throw new ConflictError('This ticket has already been used.', {
+          attendeeName: attendee.name,
+          checkedInBy,
+          checkedInAt: checkedInAt?.toISOString(),
+          sessionType: 'Main Conference (Jan 21)',
+        });
+      }
+
+      if (attendee.ticketType === TicketType.LECTURER_PREMIUM) {
+        attendee.mainConferenceCheckInStatus = CheckInStatus.CHECKED_IN;
+        attendee.mainConferenceCheckedInAt = new Date();
+        attendee.mainConferenceCheckedInBy = agent._id as any;
       } else {
-        // Main conference check-in for new system
-        const qrField =
-          attendee.ticketType === TicketType.LECTURER_PREMIUM
-            ? 'mainConferenceCheckInStatus'
-            : 'checkInStatus';
-        console.log('QR Field:', qrField);
+        attendee.checkInStatus = CheckInStatus.CHECKED_IN;
+        attendee.checkedInAt = new Date();
+        attendee.checkedInBy = agent._id as any;
+      }
 
-        const checkedInField =
-          attendee.ticketType === TicketType.LECTURER_PREMIUM
-            ? attendee.mainConferenceCheckInStatus
-            : attendee.checkInStatus;
+      await attendee.save();
 
-        if (checkedInField === CheckInStatus.CHECKED_IN) {
-          const checkedInBy =
-            attendee.ticketType === TicketType.LECTURER_PREMIUM
-              ? (attendee.mainConferenceCheckedInBy as any)?.name
-              : (attendee.checkedInBy as any)?.name;
+      await recordScanAttempt({
+        agentId: agent._id,
+        scanSource: 'qr',
+        scanStatus: 'success',
+        sessionType: sessionTypeForLog,
+        attendee,
+        message: 'Check-in successful.',
+        qrCode,
+      });
 
-          const checkedInAt =
-            attendee.ticketType === TicketType.LECTURER_PREMIUM
-              ? attendee.mainConferenceCheckedInAt
-              : attendee.checkedInAt;
+      logger.info(`Agent ${agent.email} checked in attendee ${attendee.email} for main conference`);
 
+      res.status(200).json({
+        success: true,
+        message: 'Check-in successful.',
+        data: {
+          name: attendee.name,
+          email: attendee.email,
+          ticketType: attendee.ticketType,
+          sessionType: 'Main Conference (January 21)',
+        },
+      });
+    } catch (err: any) {
+      const statusCode = err?.statusCode;
+      const scanStatus = statusCode === 409 ? 'already_scanned' : 'invalid';
+      await recordScanAttempt({
+        agentId: agent?._id,
+        scanSource: 'qr',
+        scanStatus,
+        sessionType: sessionTypeForLog,
+        attendee: attendeeForLog,
+        message: err?.message,
+        details: err?.details,
+        qrCode,
+      });
+      throw err;
+    }
+  };
+
+  private processManualCheckIn = async (
+    req: AuthenticatedRequest,
+    res: Response,
+    sessionType: 'pre-conference' | 'main-conference'
+  ) => {
+    const agent = req.user;
+    const { attendeeId } = req.body as { attendeeId?: string };
+
+    let attendeeForLog: any = undefined;
+
+    try {
+      if (agent?.role !== UserRole.AGENT) {
+        throw new ForbiddenError('Only agents can check in attendees.');
+      }
+
+      if (!attendeeId) {
+        throw new BadRequestError('attendeeId is required.');
+      }
+
+      const attendee = await User.findById(attendeeId).populate(
+        'checkedInBy preConferenceCheckedInBy mainConferenceCheckedInBy',
+        'name'
+      );
+      attendeeForLog = attendee;
+
+      if (!attendee) {
+        throw new NotFoundError('Attendee not found.');
+      }
+
+      if (attendee.role !== UserRole.USER) {
+        throw new BadRequestError('Only attendees can be checked in.');
+      }
+
+      const isLegacyTicket =
+        !attendee.mainConferenceQrCode &&
+        !attendee.preConferenceQrCode &&
+        attendee.qrCode;
+
+      if (sessionType === 'pre-conference') {
+        if (!attendee.preConferenceQrCode) {
+          throw new BadRequestError(
+            'This attendee does not have a pre-conference ticket.'
+          );
+        }
+
+        if (attendee.preConferenceCheckInStatus === CheckInStatus.CHECKED_IN) {
+          throw new ConflictError(
+            'This pre-conference ticket has already been used.',
+            {
+              attendeeName: attendee.name,
+              checkedInBy: (attendee.preConferenceCheckedInBy as any)?.name,
+              checkedInAt: attendee.preConferenceCheckedInAt?.toISOString(),
+              sessionType: 'Pre-Conference (Jan 20)',
+            }
+          );
+        }
+
+        attendee.preConferenceCheckInStatus = CheckInStatus.CHECKED_IN;
+        attendee.preConferenceCheckedInAt = new Date();
+        attendee.preConferenceCheckedInBy = agent._id as any;
+        await attendee.save();
+
+        await recordScanAttempt({
+          agentId: agent._id,
+          scanSource: 'manual',
+          scanStatus: 'success',
+          sessionType: 'pre-conference',
+          attendee,
+          message: 'Pre-conference check-in successful.',
+        });
+
+        logger.info(`Agent ${agent.email} manually checked in attendee ${attendee.email} for pre-conference`);
+
+        res.status(200).json({
+          success: true,
+          message: 'Pre-conference check-in successful.',
+          data: {
+            name: attendee.name,
+            email: attendee.email,
+            ticketType: attendee.ticketType,
+            sessionType: 'Pre-Conference (January 20)',
+          },
+        });
+        return;
+      }
+
+      // Main conference manual check-in
+      if (isLegacyTicket) {
+        if (attendee.checkInStatus === CheckInStatus.CHECKED_IN) {
           throw new ConflictError('This ticket has already been used.', {
             attendeeName: attendee.name,
-            checkedInBy,
-            checkedInAt: checkedInAt?.toISOString(),
+            checkedInBy: (attendee.checkedInBy as any)?.name,
+            checkedInAt: attendee.checkedInAt?.toISOString(),
             sessionType: 'Main Conference (Jan 21)',
           });
         }
 
-        if (attendee.ticketType === TicketType.LECTURER_PREMIUM) {
-          attendee.mainConferenceCheckInStatus = CheckInStatus.CHECKED_IN;
-          attendee.mainConferenceCheckedInAt = new Date();
-          attendee.mainConferenceCheckedInBy = agent._id as any;
-        } else {
-          attendee.checkInStatus = CheckInStatus.CHECKED_IN;
-          attendee.checkedInAt = new Date();
-          attendee.checkedInBy = agent._id as any;
-        }
-
+        attendee.checkInStatus = CheckInStatus.CHECKED_IN;
+        attendee.checkedInAt = new Date();
+        attendee.checkedInBy = agent._id as any;
         await attendee.save();
 
-        logger.info(
-          `Agent ${agent.email} checked in attendee ${attendee.email} for main conference`
-        );
+        await recordScanAttempt({
+          agentId: agent._id,
+          scanSource: 'manual',
+          scanStatus: 'success',
+          sessionType: 'main-conference',
+          attendee,
+          message: 'Check-in successful.',
+        });
+
+        logger.info(`Agent ${agent.email} manually checked in legacy ticket for attendee ${attendee.email}`);
 
         res.status(200).json({
           success: true,
@@ -180,7 +354,146 @@ class ScanController {
             sessionType: 'Main Conference (January 21)',
           },
         });
+        return;
       }
+
+      const checkedInField = attendee.ticketType === TicketType.LECTURER_PREMIUM ? attendee.mainConferenceCheckInStatus : attendee.checkInStatus;
+      if (checkedInField === CheckInStatus.CHECKED_IN) {
+        const checkedInBy = attendee.ticketType === TicketType.LECTURER_PREMIUM ? (attendee.mainConferenceCheckedInBy as any)?.name : (attendee.checkedInBy as any)?.name;
+        const checkedInAt = attendee.ticketType === TicketType.LECTURER_PREMIUM ? attendee.mainConferenceCheckedInAt : attendee.checkedInAt;
+
+        throw new ConflictError('This ticket has already been used.', {
+          attendeeName: attendee.name,
+          checkedInBy,
+          checkedInAt: checkedInAt?.toISOString(),
+          sessionType: 'Main Conference (Jan 21)',
+        });
+      }
+
+      if (attendee.ticketType === TicketType.LECTURER_PREMIUM) {
+        attendee.mainConferenceCheckInStatus = CheckInStatus.CHECKED_IN;
+        attendee.mainConferenceCheckedInAt = new Date();
+        attendee.mainConferenceCheckedInBy = agent._id as any;
+      } else {
+        attendee.checkInStatus = CheckInStatus.CHECKED_IN;
+        attendee.checkedInAt = new Date();
+        attendee.checkedInBy = agent._id as any;
+      }
+
+      await attendee.save();
+
+      await recordScanAttempt({
+        agentId: agent._id,
+        scanSource: 'manual',
+        scanStatus: 'success',
+        sessionType: 'main-conference',
+        attendee,
+        message: 'Check-in successful.',
+      });
+
+      logger.info(`Agent ${agent.email} manually checked in attendee ${attendee.email} for main conference`);
+
+      res.status(200).json({
+        success: true,
+        message: 'Check-in successful.',
+        data: {
+          name: attendee.name,
+          email: attendee.email,
+          ticketType: attendee.ticketType,
+          sessionType: 'Main Conference (January 21)',
+        },
+      });
+    } catch (err: any) {
+      const statusCode = err?.statusCode;
+      const scanStatus = statusCode === 409 ? 'already_scanned' : 'invalid';
+      await recordScanAttempt({
+        agentId: agent?._id,
+        scanSource: 'manual',
+        scanStatus,
+        sessionType,
+        attendee: attendeeForLog,
+        message: err?.message,
+        details: err?.details,
+      });
+      throw err;
+    }
+  };
+
+  scanQRCode = asyncHandler(async (req: AuthenticatedRequest, res: Response) => {
+    await this.processQRCodeCheckIn(req, res);
+  });
+
+  checkInPreConference = asyncHandler(
+    async (req: AuthenticatedRequest, res: Response) => {
+      await this.processQRCodeCheckIn(req, res, 'pre-conference');
+    }
+  );
+
+  checkInMainConference = asyncHandler(
+    async (req: AuthenticatedRequest, res: Response) => {
+      await this.processQRCodeCheckIn(req, res, 'main-conference');
+    }
+  );
+
+  manualCheckInPreConference = asyncHandler(
+    async (req: AuthenticatedRequest, res: Response) => {
+      await this.processManualCheckIn(req, res, 'pre-conference');
+    }
+  );
+
+  manualCheckInMainConference = asyncHandler(
+    async (req: AuthenticatedRequest, res: Response) => {
+      await this.processManualCheckIn(req, res, 'main-conference');
+    }
+  );
+
+  getAttendeesForAgent = asyncHandler(
+    async (req: AuthenticatedRequest, res: Response) => {
+      const agent = req.user;
+
+      if (agent?.role !== UserRole.AGENT) {
+        throw new ForbiddenError('Only agents can view attendees.');
+      }
+
+      const attendees = await User.find({ role: UserRole.USER })
+        .select(
+          [
+            'name',
+            'email',
+            'ticketType',
+            'qrCode',
+            'preConferenceQrCode',
+            'mainConferenceQrCode',
+            'checkInStatus',
+            'checkedInAt',
+            'preConferenceCheckInStatus',
+            'preConferenceCheckedInAt',
+            'mainConferenceCheckInStatus',
+            'mainConferenceCheckedInAt',
+          ].join(' ')
+        )
+        .sort({ createdAt: -1 });
+
+      const attendeeIds = attendees.map((a) => a._id);
+      const sourcesMap = await getLatestSuccessfulCheckInSourcesForAttendees(attendeeIds);
+
+      const enriched = attendees.map((a) => {
+        const obj = a.toObject();
+        const id = a._id.toString();
+        const pre = sourcesMap.get(`${id}:pre-conference`);
+        const main = sourcesMap.get(`${id}:main-conference`);
+
+        return {
+          ...obj,
+          preConferenceCheckInSource: pre?.scanSource,
+          mainConferenceCheckInSource: main?.scanSource,
+        };
+      });
+
+      res.status(200).json({
+        success: true,
+        data: enriched,
+      });
     }
   );
 
@@ -192,84 +505,11 @@ class ScanController {
         throw new ForbiddenError('Only agents can view their scan history.');
       }
 
-      // Find all users that this agent has checked in, in any capacity
-      const usersCheckedInByAgent = await User.find({
-        $or: [
-          { checkedInBy: agent._id },
-          { preConferenceCheckedInBy: agent._id },
-          { mainConferenceCheckedInBy: agent._id },
-        ],
-      })
-        .populate('checkedInBy preConferenceCheckedInBy mainConferenceCheckedInBy', 'name')
-        .sort({ 'updatedAt': -1 });
-
-      const history: any[] = [];
-
-      // Process each user to create specific history entries for each relevant check-in
-      usersCheckedInByAgent.forEach(user => {
-        // Check for standard/legacy check-in
-        if (user.checkedInBy && user.checkedInBy.toString() === agent._id.toString()) {
-          history.push({
-            _id: `${user._id}-main-legacy`,
-            name: user.name,
-            email: user.email,
-            ticketType: user.ticketType,
-            checkedInAt: user.checkedInAt,
-            checkInStatus: user.checkInStatus,
-            checkedInBy: user.checkedInBy,
-            sessionType: 'Main Conference',
-          });
-        }
-        
-        // Check for pre-conference check-in
-        if (user.preConferenceCheckedInBy && user.preConferenceCheckedInBy.toString() === agent._id.toString()) {
-          history.push({
-            _id: `${user._id}-preconf`,
-            name: user.name,
-            email: user.email,
-            ticketType: user.ticketType,
-            checkedInAt: user.preConferenceCheckedInAt,
-            checkInStatus: user.preConferenceCheckInStatus,
-            checkedInBy: user.preConferenceCheckedInBy,
-            sessionType: 'Pre-Conference',
-          });
-        }
-
-        // Check for main conference check-in (for premium tickets)
-        if (user.mainConferenceCheckedInBy && user.mainConferenceCheckedInBy.toString() === agent._id.toString()) {
-          // Avoid duplicating the standard check-in if it's the same event
-          if (!user.checkedInBy || user.checkedInBy.toString() !== agent._id.toString()) {
-            history.push({
-              _id: `${user._id}-main-premium`,
-              name: user.name,
-              email: user.email,
-              ticketType: user.ticketType,
-              checkedInAt: user.mainConferenceCheckedInAt,
-              checkInStatus: user.mainConferenceCheckInStatus,
-              checkedInBy: user.mainConferenceCheckedInBy,
-              sessionType: 'Main Conference',
-            });
-          }
-        }
-      });
-      
-      // Sort the combined history by check-in time, descending
-      history.sort((a, b) => new Date(b.checkedInAt).getTime() - new Date(a.checkedInAt).getTime());
-
-      const totalScans = history.length;
-      const successfulCheckIns = history.filter(
-        (item) => item.checkInStatus === CheckInStatus.CHECKED_IN
-      ).length;
+      const data = await getAgentScanHistoryData(agent._id);
 
       res.status(200).json({
         success: true,
-        data: {
-          history,
-          stats: {
-            totalScans,
-            successfulCheckIns,
-          },
-        },
+        data,
       });
     }
   );

--- a/server/src/controllers/scanLog.controller.ts
+++ b/server/src/controllers/scanLog.controller.ts
@@ -1,0 +1,33 @@
+import { Response } from 'express';
+import asyncHandler from '../utils/asyncHandler';
+import { AuthenticatedRequest } from '../middleware/auth.middleware';
+import { ForbiddenError, BadRequestError } from '../utils/customErrors';
+import { getScanHistoryDataForActor } from '../services/scanHistory.service';
+import { UserRole } from '../model/user.model';
+
+class ScanLogController {
+  getActorScanHistoryForAdmin = asyncHandler(
+    async (req: AuthenticatedRequest, res: Response) => {
+      if (req.user?.role !== UserRole.ADMIN) {
+        throw new ForbiddenError('Only administrators can view scan history.');
+      }
+
+      const { agentId } = req.params as { agentId?: string };
+      if (!agentId) {
+        throw new BadRequestError('agentId is required.');
+      }
+
+      const limitRaw = (req.query.limit as string | undefined) ?? '200';
+      const limit = Math.max(1, Math.min(1000, Number(limitRaw) || 200));
+
+      const data = await getScanHistoryDataForActor(agentId, { limit });
+
+      res.status(200).json({
+        success: true,
+        data,
+      });
+    }
+  );
+}
+
+export default new ScanLogController();

--- a/server/src/model/scanLog.model.ts
+++ b/server/src/model/scanLog.model.ts
@@ -1,0 +1,70 @@
+import mongoose, { Document, Schema } from 'mongoose';
+
+export type ScanStatus = 'success' | 'already_scanned' | 'invalid';
+export type ScanSource = 'qr' | 'manual';
+
+export interface IScanLog extends Document {
+  agent: Schema.Types.ObjectId;
+  attendee?: Schema.Types.ObjectId;
+
+  scanStatus: ScanStatus;
+  scanSource: ScanSource;
+  sessionType?: 'pre-conference' | 'main-conference';
+
+  attendeeName?: string;
+  attendeeEmail?: string;
+  ticketType?: string;
+
+  message?: string;
+  details?: any;
+
+  qrCodeHash?: string;
+  qrCodeSuffix?: string;
+
+  scannedAt: Date;
+}
+
+const scanLogSchema = new Schema<IScanLog>(
+  {
+    agent: { type: Schema.Types.ObjectId, ref: 'User', required: true, index: true },
+    attendee: { type: Schema.Types.ObjectId, ref: 'User', required: false, index: true },
+
+    scanStatus: {
+      type: String,
+      enum: ['success', 'already_scanned', 'invalid'],
+      required: true,
+      index: true,
+    },
+    scanSource: {
+      type: String,
+      enum: ['qr', 'manual'],
+      required: true,
+      index: true,
+    },
+    sessionType: {
+      type: String,
+      enum: ['pre-conference', 'main-conference'],
+      required: false,
+      index: true,
+    },
+
+    attendeeName: { type: String, required: false },
+    attendeeEmail: { type: String, required: false },
+    ticketType: { type: String, required: false },
+
+    message: { type: String, required: false },
+    details: { type: Schema.Types.Mixed, required: false },
+
+    qrCodeHash: { type: String, required: false, index: true },
+    qrCodeSuffix: { type: String, required: false },
+
+    scannedAt: { type: Date, default: Date.now, index: true },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+const ScanLog = mongoose.models.ScanLog || mongoose.model<IScanLog>('ScanLog', scanLogSchema);
+
+export default ScanLog;

--- a/server/src/routes/admin.routes.ts
+++ b/server/src/routes/admin.routes.ts
@@ -1,5 +1,6 @@
 import express from 'express';
 import adminController from '../controllers/admin.controller';
+import scanLogController from '../controllers/scanLog.controller';
 import {
   authenticateAdminToken,
   rateLimiter,
@@ -46,6 +47,19 @@ router.post(
   adminController.quickRegisterWithTickets
 );
 
+// Manual check-in for existing attendees
+router.post(
+  '/attendees/pre-conference/manual-check-in',
+  adminController.manualCheckInPreConference
+);
+router.post(
+  '/attendees/main-conference/manual-check-in',
+  adminController.manualCheckInMainConference
+);
+
 router.post('/attendees/instant-checkin', adminController.instantCheckIn);
+
+// Scan logs (admin)
+router.get('/agents/:agentId/scan-history', scanLogController.getActorScanHistoryForAdmin);
 
 export default router;

--- a/server/src/routes/scan.routes.ts
+++ b/server/src/routes/scan.routes.ts
@@ -7,6 +7,33 @@ const router = Router();
 // Route for agent to scan a user's QR code
 router.post('/', authenticateAgentToken, scanController.scanQRCode);
 
+// Dedicated check-in endpoints (explicit session type)
+router.post(
+  '/pre-conference/check-in',
+  authenticateAgentToken,
+  scanController.checkInPreConference
+);
+router.post(
+  '/main-conference/check-in',
+  authenticateAgentToken,
+  scanController.checkInMainConference
+);
+
+// Manual check-in endpoints (no QR scan)
+router.post(
+  '/pre-conference/manual-check-in',
+  authenticateAgentToken,
+  scanController.manualCheckInPreConference
+);
+router.post(
+  '/main-conference/manual-check-in',
+  authenticateAgentToken,
+  scanController.manualCheckInMainConference
+);
+
+// List attendees for the agent dashboard
+router.get('/attendees', authenticateAgentToken, scanController.getAttendeesForAgent);
+
 // Route for agent to get their scan history
 router.get('/history', authenticateAgentToken, scanController.getAgentScanHistory);
 

--- a/server/src/services/scanHistory.service.ts
+++ b/server/src/services/scanHistory.service.ts
@@ -1,0 +1,209 @@
+import crypto from 'crypto';
+import ScanLog from '../model/scanLog.model';
+import User from '../model/user.model';
+import logger from '../utils/logger';
+
+type SessionType = 'pre-conference' | 'main-conference';
+type ScanStatus = 'success' | 'already_scanned' | 'invalid';
+type ScanSource = 'qr' | 'manual';
+
+const hashQrCode = (qrCode?: string) => {
+  if (!qrCode) return undefined;
+  return crypto.createHash('sha256').update(qrCode).digest('hex');
+};
+
+const qrSuffix = (qrCode?: string) => {
+  if (!qrCode) return undefined;
+  return qrCode.length <= 8 ? qrCode : qrCode.slice(-8);
+};
+
+export const recordScanAttempt = async (params: {
+  agentId: any;
+  scanSource: ScanSource;
+  scanStatus: ScanStatus;
+  sessionType?: SessionType;
+  attendee?: any;
+  message?: string;
+  details?: any;
+  qrCode?: string;
+}) => {
+  try {
+    await ScanLog.create({
+      agent: params.agentId,
+      attendee: params.attendee?._id,
+      scanSource: params.scanSource,
+      scanStatus: params.scanStatus,
+      sessionType: params.sessionType,
+      attendeeName: params.attendee?.name,
+      attendeeEmail: params.attendee?.email,
+      ticketType: params.attendee?.ticketType,
+      message: params.message,
+      details: params.details,
+      qrCodeHash: hashQrCode(params.qrCode),
+      qrCodeSuffix: qrSuffix(params.qrCode),
+      scannedAt: new Date(),
+    });
+  } catch (err) {
+    logger.error('Failed to record scan attempt', err);
+  }
+};
+
+export const getScanHistoryDataForActor = async (
+  actorId: any,
+  options?: { limit?: number }
+) => {
+  const limit = Math.max(1, Math.min(1000, options?.limit ?? 200));
+
+  const logs = await ScanLog.find({ agent: actorId })
+    .sort({ scannedAt: -1 })
+    .limit(limit)
+    .lean();
+
+  const logHistory = logs.map((log: any) => ({
+    _id: log._id,
+    name: log.attendeeName || 'Unknown',
+    email: log.attendeeEmail || '',
+    ticketType: log.ticketType || '',
+    scannedAt: log.scannedAt,
+    scanStatus: log.scanStatus,
+    scanSource: log.scanSource,
+    message: log.message,
+    details: log.details,
+    sessionType: log.sessionType,
+  }));
+
+  // Backwards-compatible: include older successful check-ins (before ScanLog existed).
+  const oldestLoggedAt = logs.length > 0 ? logs[logs.length - 1].scannedAt : undefined;
+
+  const usersCheckedInByActor = await User.find({
+    $or: [
+      { checkedInBy: actorId },
+      { preConferenceCheckedInBy: actorId },
+      { mainConferenceCheckedInBy: actorId },
+    ],
+  })
+    .select(
+      [
+        'name',
+        'email',
+        'ticketType',
+        'checkedInAt',
+        'checkedInBy',
+        'preConferenceCheckedInAt',
+        'preConferenceCheckedInBy',
+        'mainConferenceCheckedInAt',
+        'mainConferenceCheckedInBy',
+      ].join(' ')
+    )
+    .sort({ updatedAt: -1 })
+    .lean();
+
+  const isSameAgent = (checkedInBy: any) => {
+    if (!checkedInBy || !actorId) return false;
+    const checkedInById = checkedInBy?._id ?? checkedInBy;
+    return checkedInById?.toString?.() === actorId.toString();
+  };
+
+  const history: any[] = [];
+
+  usersCheckedInByActor.forEach((user: any) => {
+    if (isSameAgent(user.checkedInBy)) {
+      history.push({
+        _id: `${user._id}-main-legacy`,
+        name: user.name,
+        email: user.email,
+        ticketType: user.ticketType,
+        scannedAt: user.checkedInAt,
+        scanStatus: 'success',
+        scanSource: 'qr',
+        sessionType: 'main-conference',
+      });
+    }
+
+    if (isSameAgent(user.preConferenceCheckedInBy)) {
+      history.push({
+        _id: `${user._id}-preconf`,
+        name: user.name,
+        email: user.email,
+        ticketType: user.ticketType,
+        scannedAt: user.preConferenceCheckedInAt,
+        scanStatus: 'success',
+        scanSource: 'qr',
+        sessionType: 'pre-conference',
+      });
+    }
+
+    if (isSameAgent(user.mainConferenceCheckedInBy) && !isSameAgent(user.checkedInBy)) {
+      history.push({
+        _id: `${user._id}-main-premium`,
+        name: user.name,
+        email: user.email,
+        ticketType: user.ticketType,
+        scannedAt: user.mainConferenceCheckedInAt,
+        scanStatus: 'success',
+        scanSource: 'qr',
+        sessionType: 'main-conference',
+      });
+    }
+  });
+
+  history.sort((a, b) => new Date(b.scannedAt).getTime() - new Date(a.scannedAt).getTime());
+
+  const legacyHistory = oldestLoggedAt ? history.filter((h) => h.scannedAt && new Date(h.scannedAt) < new Date(oldestLoggedAt)) : history;
+
+  const combinedHistory = [...logHistory, ...legacyHistory].sort(
+    (a, b) => new Date(b.scannedAt).getTime() - new Date(a.scannedAt).getTime()
+  );
+
+  return {
+    history: combinedHistory,
+    stats: {
+      totalScans: combinedHistory.length,
+      successfulCheckIns: combinedHistory.filter((item) => item.scanStatus === 'success').length,
+      successfulManualCheckIns: combinedHistory.filter(
+        (item) => item.scanStatus === 'success' && item.scanSource === 'manual'
+      ).length,
+      successfulQrScans: combinedHistory.filter(
+        (item) => item.scanStatus === 'success' && item.scanSource === 'qr'
+      ).length,
+    },
+  };
+};
+
+// Backwards-compatible name (used by agent route)
+export const getAgentScanHistoryData = (agentId: any) => getScanHistoryDataForActor(agentId);
+
+export const getLatestSuccessfulCheckInSourcesForAttendees = async (attendeeIds: any[]) => {
+  if (!attendeeIds || attendeeIds.length === 0) return new Map<string, any>();
+
+  const rows = await ScanLog.aggregate([
+    {
+      $match: {
+        attendee: { $in: attendeeIds },
+        scanStatus: 'success',
+        sessionType: { $in: ['pre-conference', 'main-conference'] },
+      },
+    },
+    { $sort: { scannedAt: -1 } },
+    {
+      $group: {
+        _id: { attendee: '$attendee', sessionType: '$sessionType' },
+        scanSource: { $first: '$scanSource' },
+        actor: { $first: '$agent' },
+        scannedAt: { $first: '$scannedAt' },
+      },
+    },
+  ]);
+
+  const map = new Map<string, any>();
+  rows.forEach((r: any) => {
+    const attendeeId = r._id?.attendee?.toString?.() ?? String(r._id?.attendee);
+    const sessionType = r._id?.sessionType;
+    map.set(`${attendeeId}:${sessionType}`, {
+      scanSource: r.scanSource,
+      actor: r.actor,
+      scannedAt: r.scannedAt,
+    });
+  });
+  return map;
+};


### PR DESCRIPTION
## Summary

This PR enhances both **admin** and **agent** dashboards by improving check-in management, visibility, and auditing, and adds **CI coverage** for client and server builds.

### Key Changes
- **Manual Check-Ins (Admin)**
  - Admins can manually check in attendees for pre-conference and main sessions.
  - Clear confirmation dialogs with irreversible-action warnings.
  - Check-in source is now tracked and displayed (**QR vs Manual**).

- **Agent Scan History & Stats**
  - New admin UI to view agent scan histories (QR + manual).
  - Color-coded statuses and detailed statistics (total scans, success rate, QR/manual breakdown).

- **Agent Dashboard Improvements**
  - Scan history and stats now include manual check-ins.
  - Source badges and improved scan time formatting.

- **Data Model Updates**
  - Added check-in source fields for consistent tracking and display across dashboards.

- **CI Improvements**
  - Introduced separate GitHub Actions workflows for **client** and **server** linting/builds on `dev` and `main`.

## Impact
- Better operational flexibility via manual check-ins.
- Improved transparency and auditability of agent activity.
- Stronger build validation through dedicated CI workflows.
